### PR TITLE
fix(toolbox): fix Create Pull Request form not scrolling in inline mo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Barrel export for all dashboard components and utilities (`components/dashboard/index.ts`)
   - All widgets fetch data directly from GitHub API — no dependency on local contributions store
   - Graceful degradation: widgets detect missing GitHub token and show "Connect GitHub in Settings" prompt
-  - "Open in Cola Records" navigation: PRs and Issues widgets include a per-entry button that matches `repoFullName` to a local Contribution record and opens the project in the IDE via `DashboardScreen` → `App.tsx` `handleOpenIDE` callback plumbing
+  - "Open in Cola Records" navigation: PRs, Issues, and CI/CD widgets include a per-entry button that matches `repoFullName` to a local Contribution record and opens the project in the IDE via `DashboardScreen` → `App.tsx` `handleOpenIDE` callback plumbing
 - Auto-assign issue to authenticated user when clicking "Fix Issue" in the Issues tool ([#18](https://github.com/lukadfagundes/cola-records/issues/18))
   - New `github:add-assignees` IPC channel wrapping `client.issues.addAssignees`
   - New `addAssignees()` method in `GitHubRestService`
   - Best-effort assignment after branch creation — failure does not block the Fix Issue flow
+
+### Fixed
+
+- Fixed Create Pull Request form not scrolling in Tool Box inline mode ([#25](https://github.com/lukadfagundes/cola-records/issues/25))
+  - Removed `overflow-hidden` from `formContent` wrapper in `CreatePullRequestModal` which was blocking the outer scroll container
+  - Title, Description, and Submit button are now reachable when the comparison preview is tall
 
 ### Tests
 
@@ -39,11 +45,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `PRsNeedingAttentionWidget.test.tsx`: 9 tests covering PR list, review/CI icons, empty state, 10-item limit, `involves:` query, Open button callback, no Open button without prop, error handling
   - `OpenIssuesWidget.test.tsx`: 11 tests covering issue list, labels, 10-item limit, noToken, dual-query merge/dedup, assigned + authored results, Open button callback, no Open button without prop, error handling
   - `RecentActivityWidget.test.tsx`: 9 tests covering event descriptions (push/PR/issue/create), 10-item limit, noToken, error handling
-  - `CICDStatusWidget.test.tsx`: 11 tests covering pipeline list, status dots (green/red/yellow), empty repos, all-rejected error surfacing, noToken, all repos processed (no 5-repo limit), 10-pipeline display limit
-  - `DashboardScreen.test.tsx`: 8 tests covering header, widget composition, grid layout, scrollable area, `onOpenIDE` prop plumbing to PRs and Issues widgets
+  - `CICDStatusWidget.test.tsx`: 13 tests covering pipeline list, status dots (green/red/yellow), empty repos, all-rejected error surfacing, noToken, all repos processed (no 5-repo limit), 10-pipeline display limit, Open button callback, no Open button without prop
+  - `DashboardScreen.test.tsx`: 8 tests covering header, widget composition, grid layout, scrollable area, `onOpenIDE` prop plumbing to PRs, Issues, and CI/CD widgets
   - `github-rest.service.test.ts`: 9 new tests for `searchIssuesAndPullRequests` and `listUserEvents` (field mapping, query pass-through, empty results, API errors)
   - `github-rest.service.test.ts`: 2 new tests for `addAssignees` (correct params, API error)
   - `DevelopmentIssueDetailModal.test.tsx`: 2 new tests for Fix Issue auto-assign (assigns user after branch creation, completes when assignment fails)
+  - `CreatePullRequestModal.test.tsx`: 1 new test for inline mode scrollable container regression check
 
 ## [1.0.4] - 2026-02-17
 

--- a/src/renderer/components/pull-requests/CreatePullRequestModal.tsx
+++ b/src/renderer/components/pull-requests/CreatePullRequestModal.tsx
@@ -337,7 +337,7 @@ export function CreatePullRequestModal({
   };
 
   const formContent = (
-    <div className="space-y-4 min-w-0 overflow-hidden">
+    <div className="space-y-4 min-w-0">
       {/* Branch Selectors */}
       <div className="grid grid-cols-[1fr_auto_1fr] gap-3 items-end">
         <div>

--- a/tests/renderer/components/pull-requests/CreatePullRequestModal.test.tsx
+++ b/tests/renderer/components/pull-requests/CreatePullRequestModal.test.tsx
@@ -218,4 +218,30 @@ describe('CreatePullRequestModal', () => {
       expect(comboboxes[1].textContent).toContain('develop');
     });
   });
+
+  it('inline mode renders scrollable container with all form fields accessible', async () => {
+    const { container } = render(<CreatePullRequestModal {...defaultProps} inline={true} />);
+
+    // Wait for init to complete (sets base, compare, title)
+    await waitFor(() => {
+      const titleInput = screen.getByPlaceholderText('Pull request title') as HTMLInputElement;
+      expect(titleInput.value).not.toBe('');
+    });
+
+    // The outer inline wrapper should be scrollable
+    const scrollContainer = container.querySelector('.overflow-auto');
+    expect(scrollContainer).not.toBeNull();
+
+    // Heading rendered inline (not inside Dialog)
+    expect(screen.getByRole('heading', { name: 'Create Pull Request' })).toBeInTheDocument();
+
+    // All form fields accessible
+    expect(screen.getByText('Description')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Create Pull Request/ })).toBeInTheDocument();
+
+    // formContent should NOT have overflow-hidden (the bug fix)
+    const formContent = container.querySelector('.space-y-4.min-w-0');
+    expect(formContent).not.toBeNull();
+    expect(formContent!.classList.contains('overflow-hidden')).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

- Fix Create Pull Request form not scrolling when the comparison preview is tall in Tool Box inline mode
- `overflow-hidden` on the `formContent` wrapper was blocking the outer scroll container, making Title, Description, and Submit button unreachable

