### PR TITLE
fix(toolbox): fix terminal overflow breaking Tool Box layout (#26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Create Pull Request form not scrolling in Tool Box inline mode ([#25](https://github.com/lukadfagundes/cola-records/issues/25))
   - Removed `overflow-hidden` from `formContent` wrapper in `CreatePullRequestModal` which was blocking the outer scroll container
   - Title, Description, and Submit button are now reachable when the comparison preview is tall
+- Fixed terminal output overflow breaking Tool Box layout ([#26](https://github.com/lukadfagundes/cola-records/issues/26))
+  - Replaced `calc(100% - terminalHeight)` with flex-based layout in ToolsPanel to prevent ~44px overflow when header and drag handle were unaccounted for
+  - Added `overflow-hidden` to ToolsPanel wrapper in DevelopmentScreen for containment
+  - Header now has explicit `shrink-0` to prevent compression when terminal is large
 
 ### Tests
 
@@ -51,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `github-rest.service.test.ts`: 2 new tests for `addAssignees` (correct params, API error)
   - `DevelopmentIssueDetailModal.test.tsx`: 2 new tests for Fix Issue auto-assign (assigns user after branch creation, completes when assignment fails)
   - `CreatePullRequestModal.test.tsx`: 1 new test for inline mode scrollable container regression check
+  - `ToolsPanel.test.tsx`: 1 new test for flex-based tool content layout regression guard ([#26](https://github.com/lukadfagundes/cola-records/issues/26))
 
 ## [1.0.4] - 2026-02-17
 

--- a/src/renderer/components/tools/ToolsPanel.tsx
+++ b/src/renderer/components/tools/ToolsPanel.tsx
@@ -199,7 +199,7 @@ export function ToolsPanel({
       )}
 
       {/* Header with hamburger menu */}
-      <div className="flex items-center justify-between px-3 py-2 border-b border-border bg-muted/30">
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border bg-muted/30 shrink-0">
         <div className="relative">
           <Button
             variant="ghost"
@@ -250,14 +250,7 @@ export function ToolsPanel({
       </div>
 
       {/* Tool content — fills remaining space minus terminal */}
-      <div
-        className="overflow-hidden"
-        style={
-          terminalExpanded
-            ? { flex: 'none', height: `calc(100% - ${terminalHeight}px)` }
-            : { flex: 1 }
-        }
-      >
+      <div className="overflow-hidden" style={{ flex: 1, minHeight: 0 }}>
         {renderTool()}
       </div>
 

--- a/src/renderer/screens/DevelopmentScreen.tsx
+++ b/src/renderer/screens/DevelopmentScreen.tsx
@@ -512,7 +512,7 @@ export function DevelopmentScreen({
             <div
               ref={toolsPanelRef}
               style={toolsPanelWidth > 0 ? { width: toolsPanelWidth } : { flex: 1 }}
-              className="shrink-0 h-full"
+              className="shrink-0 h-full overflow-hidden"
             >
               <ToolsPanel
                 workingDirectory={contribution.localPath}

--- a/tests/renderer/components/tools/ToolsPanel.test.tsx
+++ b/tests/renderer/components/tools/ToolsPanel.test.tsx
@@ -265,6 +265,24 @@ describe('ToolsPanel', () => {
       expect(dragHandle).not.toBeNull();
     });
 
+    it('tool content uses flex layout (no calc overflow) when terminal is expanded', async () => {
+      const user = userEvent.setup();
+      const { container } = render(
+        <ToolsPanel workingDirectory={workingDirectory} onClose={mockOnClose} />
+      );
+
+      // Expand terminal
+      const terminalBar = screen.getByText('Terminal').closest('div');
+      await user.click(terminalBar as HTMLElement);
+
+      // Tool content should use flex:1, NOT a calc() height
+      const toolContent = container.querySelector('.overflow-hidden[style]');
+      expect(toolContent).not.toBeNull();
+      const style = (toolContent as HTMLElement).style;
+      expect(style.flex).toContain('1');
+      expect(style.height).toBe('');
+    });
+
     it('terminal bar is visible regardless of active tool', async () => {
       const user = userEvent.setup();
       render(<ToolsPanel workingDirectory={workingDirectory} onClose={mockOnClose} />);


### PR DESCRIPTION
## Summary

- Replaced broken `calc(100% - terminalHeight)` height calculation in ToolsPanel with proper `flex: 1` + `minHeight: 0` layout — the calc didn't account for the header (~40px) and drag handle (4px), causing ~44px overflow that pushed the entire Tool Box below the code server viewport
- Added `shrink-0` to ToolsPanel header to prevent compression when terminal is large
- Added `overflow-hidden` to ToolsPanel wrapper in DevelopmentScreen as defense-in-depth

Closes #26