### PR TITLE
fix(dev-scripts): scope scripts per project to prevent cross-project …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Replaced `calc(100% - terminalHeight)` with flex-based layout in ToolsPanel to prevent ~44px overflow when header and drag handle were unaccounted for
   - Added `overflow-hidden` to ToolsPanel wrapper in DevelopmentScreen for containment
   - Header now has explicit `shrink-0` to prevent compression when terminal is large
+- Fixed dev scripts from wrong project appearing in header and Tool Box when multiple projects open ([#24](https://github.com/lukadfagundes/cola-records/issues/24))
+  - Changed `useDevScriptsStore` to merge scripts from multiple projects instead of replacing the global array
+  - Added `selectScriptsForProject()` utility for consumer-side filtering by `projectPath`
+  - `DevelopmentScreen` header buttons now filter by `contribution.localPath`
+  - `DevScriptsTool` script list now filters by `workingDirectory`
 
 ### Tests
 
@@ -56,6 +61,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `DevelopmentIssueDetailModal.test.tsx`: 2 new tests for Fix Issue auto-assign (assigns user after branch creation, completes when assignment fails)
   - `CreatePullRequestModal.test.tsx`: 1 new test for inline mode scrollable container regression check
   - `ToolsPanel.test.tsx`: 1 new test for flex-based tool content layout regression guard ([#26](https://github.com/lukadfagundes/cola-records/issues/26))
+- Dev script overrun fix tests ([#24](https://github.com/lukadfagundes/cola-records/issues/24))
+  - `useDevScriptsStore.test.ts`: 6 new tests for multi-project merge behavior and `selectScriptsForProject`
+  - `DevScriptsTool.test.tsx`: 2 new tests for cross-project script isolation
+  - Updated existing "different project paths" test for merge semantics
+  - Updated store mocks in 4 DevelopmentScreen test files and ToolsPanel test to export `selectScriptsForProject`
 
 ## [1.0.4] - 2026-02-17
 

--- a/src/renderer/components/tools/DevScriptsTool.tsx
+++ b/src/renderer/components/tools/DevScriptsTool.tsx
@@ -5,7 +5,7 @@
  * Scripts appear as buttons in the Development screen header for quick execution.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   Plus,
   Pencil,
@@ -20,7 +20,7 @@ import {
   Layers,
 } from 'lucide-react';
 import { Button } from '../ui/Button';
-import { useDevScriptsStore } from '../../stores/useDevScriptsStore';
+import { useDevScriptsStore, selectScriptsForProject } from '../../stores/useDevScriptsStore';
 import type { DevScript, DevScriptTerminal } from '../../../main/ipc/channels';
 import { cn } from '../../lib/utils';
 
@@ -29,7 +29,17 @@ interface DevScriptsToolProps {
 }
 
 export function DevScriptsTool({ workingDirectory }: DevScriptsToolProps) {
-  const { scripts, loading, loadScripts, saveScript, deleteScript } = useDevScriptsStore();
+  const {
+    scripts: allScripts,
+    loading,
+    loadScripts,
+    saveScript,
+    deleteScript,
+  } = useDevScriptsStore();
+  const scripts = useMemo(
+    () => selectScriptsForProject(allScripts, workingDirectory),
+    [allScripts, workingDirectory]
+  );
 
   // Form state
   const [isFormOpen, setIsFormOpen] = useState(false);

--- a/src/renderer/screens/DevelopmentScreen.tsx
+++ b/src/renderer/screens/DevelopmentScreen.tsx
@@ -5,14 +5,14 @@
  * State machine: idle → starting → running → error
  */
 
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { ipc } from '../ipc/client';
 import type { Contribution, DevScript } from '../../main/ipc/channels';
 import { BranchDetailModal } from '../components/branches/BranchDetailModal';
 import { ToolsPanel } from '../components/tools/ToolsPanel';
 import { ScriptButton } from '../components/tools/ScriptButton';
 import { ScriptExecutionModal } from '../components/tools/ScriptExecutionModal';
-import { useDevScriptsStore } from '../stores/useDevScriptsStore';
+import { useDevScriptsStore, selectScriptsForProject } from '../stores/useDevScriptsStore';
 
 type ScreenState = 'idle' | 'starting' | 'running' | 'error';
 
@@ -123,7 +123,11 @@ export function DevelopmentScreen({
   );
 
   // Dev scripts store
-  const { scripts: devScripts, loadScripts: loadDevScripts } = useDevScriptsStore();
+  const { scripts: allScripts, loadScripts: loadDevScripts } = useDevScriptsStore();
+  const devScripts = useMemo(
+    () => selectScriptsForProject(allScripts, contribution.localPath),
+    [allScripts, contribution.localPath]
+  );
 
   // Fetch remotes on mount (needed for PR creation fork detection)
   useEffect(() => {

--- a/src/renderer/stores/useDevScriptsStore.ts
+++ b/src/renderer/stores/useDevScriptsStore.ts
@@ -27,8 +27,11 @@ export const useDevScriptsStore = create<DevScriptsState>((set, get) => ({
   loadScripts: async (projectPath: string) => {
     set({ loading: true, error: null });
     try {
-      const scripts = await ipc.invoke('dev-scripts:get-all', projectPath);
-      set({ scripts, loading: false });
+      const loaded = await ipc.invoke('dev-scripts:get-all', projectPath);
+      set((state) => ({
+        scripts: [...state.scripts.filter((s) => s.projectPath !== projectPath), ...loaded],
+        loading: false,
+      }));
     } catch (error) {
       set({ error: String(error), loading: false });
     }
@@ -39,8 +42,11 @@ export const useDevScriptsStore = create<DevScriptsState>((set, get) => ({
     try {
       await ipc.invoke('dev-scripts:save', script);
       // Reload scripts to get updated list
-      const scripts = await ipc.invoke('dev-scripts:get-all', script.projectPath);
-      set({ scripts, loading: false });
+      const loaded = await ipc.invoke('dev-scripts:get-all', script.projectPath);
+      set((state) => ({
+        scripts: [...state.scripts.filter((s) => s.projectPath !== script.projectPath), ...loaded],
+        loading: false,
+      }));
     } catch (error) {
       set({ error: String(error), loading: false });
       throw error;
@@ -56,8 +62,11 @@ export const useDevScriptsStore = create<DevScriptsState>((set, get) => ({
     try {
       await ipc.invoke('dev-scripts:delete', id);
       // Reload scripts to get updated list
-      const updatedScripts = await ipc.invoke('dev-scripts:get-all', script.projectPath);
-      set({ scripts: updatedScripts, loading: false });
+      const loaded = await ipc.invoke('dev-scripts:get-all', script.projectPath);
+      set((state) => ({
+        scripts: [...state.scripts.filter((s) => s.projectPath !== script.projectPath), ...loaded],
+        loading: false,
+      }));
     } catch (error) {
       set({ error: String(error), loading: false });
       throw error;
@@ -72,3 +81,8 @@ export const useDevScriptsStore = create<DevScriptsState>((set, get) => ({
     set({ activeTerminalSession: sessionId });
   },
 }));
+
+/** Select only scripts belonging to a specific project path */
+export function selectScriptsForProject(scripts: DevScript[], projectPath: string): DevScript[] {
+  return scripts.filter((s) => s.projectPath === projectPath);
+}

--- a/tests/renderer/components/tools/DevScriptsTool.test.tsx
+++ b/tests/renderer/components/tools/DevScriptsTool.test.tsx
@@ -31,6 +31,8 @@ vi.mock('../../../../src/renderer/stores/useDevScriptsStore', () => ({
     saveScript: mockSaveScript,
     deleteScript: mockDeleteScript,
   }),
+  selectScriptsForProject: (scripts: any[], projectPath: string) =>
+    scripts.filter((s: any) => s.projectPath === projectPath),
 }));
 
 import { DevScriptsTool } from '../../../../src/renderer/components/tools/DevScriptsTool';
@@ -64,8 +66,18 @@ describe('DevScriptsTool', () => {
 
     it('should render script list when scripts exist', () => {
       mockStoreState.scripts = [
-        createMockDevScript({ id: 'script_1', name: 'Build', command: 'npm run build' }),
-        createMockDevScript({ id: 'script_2', name: 'Test', command: 'npm test' }),
+        createMockDevScript({
+          id: 'script_1',
+          name: 'Build',
+          command: 'npm run build',
+          projectPath: '/test/project/path',
+        }),
+        createMockDevScript({
+          id: 'script_2',
+          name: 'Test',
+          command: 'npm test',
+          projectPath: '/test/project/path',
+        }),
       ];
 
       render(<DevScriptsTool {...defaultProps} />);
@@ -273,6 +285,7 @@ describe('DevScriptsTool', () => {
           name: 'Build',
           command: 'npm run build',
           commands: ['npm run build'],
+          projectPath: '/test/project/path',
         }),
       ];
 
@@ -300,6 +313,7 @@ describe('DevScriptsTool', () => {
           name: 'Build',
           command: 'npm run build',
           commands: ['npm run build'],
+          projectPath: '/test/project/path',
         }),
       ];
       mockSaveScript.mockResolvedValueOnce(undefined);
@@ -337,6 +351,7 @@ describe('DevScriptsTool', () => {
           name: 'Build',
           command: 'npm run build',
           commands: ['npm run build'],
+          projectPath: '/test/project/path',
         }),
       ];
 
@@ -368,6 +383,7 @@ describe('DevScriptsTool', () => {
           name: 'Build',
           command: 'npm run build',
           commands: ['npm run build'],
+          projectPath: '/test/project/path',
         }),
       ];
 
@@ -390,6 +406,7 @@ describe('DevScriptsTool', () => {
           name: 'Build',
           command: 'npm run build',
           commands: ['npm run build'],
+          projectPath: '/test/project/path',
         }),
       ];
       mockDeleteScript.mockResolvedValueOnce(undefined);
@@ -419,6 +436,7 @@ describe('DevScriptsTool', () => {
           name: 'Build',
           command: 'npm run build',
           commands: ['npm run build'],
+          projectPath: '/test/project/path',
         }),
       ];
 
@@ -449,6 +467,7 @@ describe('DevScriptsTool', () => {
         name: 'Build',
         command: 'npm run build',
         commands: ['npm run build'],
+        projectPath: '/test/project/path',
       });
       mockStoreState.scripts = [mockScript];
 
@@ -479,6 +498,7 @@ describe('DevScriptsTool', () => {
           name: 'Build',
           command: 'npm run build',
           commands: ['npm run build'],
+          projectPath: '/test/project/path',
         }),
       ];
 
@@ -509,6 +529,40 @@ describe('DevScriptsTool', () => {
       await waitFor(() => {
         expect(screen.getByText('A script with this name already exists')).toBeDefined();
       });
+    });
+  });
+
+  describe('multi-project isolation', () => {
+    it('should not show scripts from a different project', () => {
+      mockStoreState.scripts = [
+        createMockDevScript({
+          id: 'script_other',
+          name: 'Other Build',
+          projectPath: '/other/project',
+        }),
+      ];
+
+      render(<DevScriptsTool {...defaultProps} />);
+      expect(screen.getByText('No scripts yet')).toBeDefined();
+    });
+
+    it('should show only scripts matching workingDirectory', () => {
+      mockStoreState.scripts = [
+        createMockDevScript({
+          id: 'script_mine',
+          name: 'My Build',
+          projectPath: '/test/project/path',
+        }),
+        createMockDevScript({
+          id: 'script_other',
+          name: 'Other Build',
+          projectPath: '/other/project',
+        }),
+      ];
+
+      render(<DevScriptsTool {...defaultProps} />);
+      expect(screen.getByText('My Build')).toBeDefined();
+      expect(screen.queryByText('Other Build')).toBeNull();
     });
   });
 });

--- a/tests/renderer/components/tools/ToolsPanel.test.tsx
+++ b/tests/renderer/components/tools/ToolsPanel.test.tsx
@@ -49,6 +49,8 @@ vi.mock('../../../../src/renderer/stores/useDevScriptsStore', () => ({
     saveScript: vi.fn(),
     deleteScript: vi.fn(),
   }),
+  selectScriptsForProject: (scripts: any[], projectPath: string) =>
+    scripts.filter((s: any) => s.projectPath === projectPath),
 }));
 
 import { ToolsPanel } from '../../../../src/renderer/components/tools/ToolsPanel';

--- a/tests/renderer/screens/DevelopmentScreen.dev-scripts.test.tsx
+++ b/tests/renderer/screens/DevelopmentScreen.dev-scripts.test.tsx
@@ -44,6 +44,8 @@ let mockDevScriptsState = {
 
 vi.mock('../../../src/renderer/stores/useDevScriptsStore', () => ({
   useDevScriptsStore: () => mockDevScriptsState,
+  selectScriptsForProject: (scripts: any[], projectPath: string) =>
+    scripts.filter((s: any) => s.projectPath === projectPath),
 }));
 
 // Mock ScriptButton

--- a/tests/renderer/screens/DevelopmentScreen.toolbar.test.tsx
+++ b/tests/renderer/screens/DevelopmentScreen.toolbar.test.tsx
@@ -50,6 +50,8 @@ vi.mock('../../../src/renderer/stores/useDevScriptsStore', () => ({
     saveScript: vi.fn(),
     deleteScript: vi.fn(),
   }),
+  selectScriptsForProject: (scripts: any[], projectPath: string) =>
+    scripts.filter((s: any) => s.projectPath === projectPath),
 }));
 
 // Mock ScriptButton

--- a/tests/renderer/screens/DevelopmentScreen.tools.test.tsx
+++ b/tests/renderer/screens/DevelopmentScreen.tools.test.tsx
@@ -61,6 +61,8 @@ vi.mock('../../../src/renderer/stores/useDevScriptsStore', () => ({
     saveScript: vi.fn(),
     deleteScript: vi.fn(),
   }),
+  selectScriptsForProject: (scripts: any[], projectPath: string) =>
+    scripts.filter((s: any) => s.projectPath === projectPath),
 }));
 
 // Mock ScriptButton

--- a/tests/renderer/stores/useDevScriptsStore.test.ts
+++ b/tests/renderer/stores/useDevScriptsStore.test.ts
@@ -14,7 +14,10 @@ vi.mock('../../../src/renderer/ipc/client', () => ({
   },
 }));
 
-import { useDevScriptsStore } from '../../../src/renderer/stores/useDevScriptsStore';
+import {
+  useDevScriptsStore,
+  selectScriptsForProject,
+} from '../../../src/renderer/stores/useDevScriptsStore';
 
 describe('useDevScriptsStore', () => {
   beforeEach(() => {
@@ -405,7 +408,10 @@ describe('useDevScriptsStore', () => {
 
   describe('edge cases', () => {
     it('should handle loading same scripts multiple times', async () => {
-      const scripts = createMockDevScriptsList();
+      const scripts = createMockDevScriptsList().map((s) => ({
+        ...s,
+        projectPath: '/test/project',
+      }));
       mockInvoke.mockResolvedValue(scripts);
 
       await act(async () => {
@@ -420,9 +426,9 @@ describe('useDevScriptsStore', () => {
       expect(useDevScriptsStore.getState().scripts).toHaveLength(3);
     });
 
-    it('should handle loading different project paths', async () => {
-      const scripts1 = [createMockDevScript({ projectPath: '/project/one' })];
-      const scripts2 = [createMockDevScript({ projectPath: '/project/two' })];
+    it('should merge scripts when loading different project paths', async () => {
+      const scripts1 = [createMockDevScript({ id: 'a1', projectPath: '/project/one' })];
+      const scripts2 = [createMockDevScript({ id: 'b1', projectPath: '/project/two' })];
 
       mockInvoke.mockResolvedValueOnce(scripts1);
 
@@ -438,8 +444,11 @@ describe('useDevScriptsStore', () => {
         await useDevScriptsStore.getState().loadScripts('/project/two');
       });
 
-      // Should replace with new scripts
-      expect(useDevScriptsStore.getState().scripts).toEqual(scripts2);
+      // Should contain scripts from BOTH projects
+      const state = useDevScriptsStore.getState();
+      expect(state.scripts).toHaveLength(2);
+      expect(state.scripts.find((s) => s.id === 'a1')).toBeDefined();
+      expect(state.scripts.find((s) => s.id === 'b1')).toBeDefined();
     });
 
     it('should handle empty scripts array', async () => {
@@ -452,6 +461,70 @@ describe('useDevScriptsStore', () => {
       expect(useDevScriptsStore.getState().scripts).toEqual([]);
       expect(useDevScriptsStore.getState().loading).toBe(false);
       expect(useDevScriptsStore.getState().error).toBeNull();
+    });
+
+    it('should replace only scripts for the reloaded project on re-load', async () => {
+      // Pre-populate with scripts from two projects
+      useDevScriptsStore.setState({
+        scripts: [
+          createMockDevScript({ id: 'a1', projectPath: '/project/a', name: 'Old A' }),
+          createMockDevScript({ id: 'b1', projectPath: '/project/b', name: 'B Script' }),
+        ],
+      });
+
+      const updatedA = [
+        createMockDevScript({ id: 'a2', projectPath: '/project/a', name: 'New A' }),
+      ];
+      mockInvoke.mockResolvedValueOnce(updatedA);
+
+      await act(async () => {
+        await useDevScriptsStore.getState().loadScripts('/project/a');
+      });
+
+      const state = useDevScriptsStore.getState();
+      expect(state.scripts).toHaveLength(2);
+      expect(state.scripts.find((s) => s.id === 'a1')).toBeUndefined();
+      expect(state.scripts.find((s) => s.id === 'a2')).toBeDefined();
+      expect(state.scripts.find((s) => s.id === 'b1')).toBeDefined();
+    });
+
+    it('should preserve other projects scripts on save', async () => {
+      useDevScriptsStore.setState({
+        scripts: [createMockDevScript({ id: 'b1', projectPath: '/project/b' })],
+      });
+
+      const newScript = createMockDevScript({ id: 'a1', projectPath: '/project/a' });
+      mockInvoke.mockResolvedValueOnce(undefined); // save
+      mockInvoke.mockResolvedValueOnce([newScript]); // reload for project/a
+
+      await act(async () => {
+        await useDevScriptsStore.getState().saveScript(newScript);
+      });
+
+      const state = useDevScriptsStore.getState();
+      expect(state.scripts).toHaveLength(2);
+      expect(state.scripts.find((s) => s.id === 'b1')).toBeDefined();
+      expect(state.scripts.find((s) => s.id === 'a1')).toBeDefined();
+    });
+
+    it('should preserve other projects scripts on delete', async () => {
+      useDevScriptsStore.setState({
+        scripts: [
+          createMockDevScript({ id: 'a1', projectPath: '/project/a' }),
+          createMockDevScript({ id: 'b1', projectPath: '/project/b' }),
+        ],
+      });
+
+      mockInvoke.mockResolvedValueOnce(undefined); // delete
+      mockInvoke.mockResolvedValueOnce([]); // reload for project/a (empty after delete)
+
+      await act(async () => {
+        await useDevScriptsStore.getState().deleteScript('a1');
+      });
+
+      const state = useDevScriptsStore.getState();
+      expect(state.scripts).toHaveLength(1);
+      expect(state.scripts[0].id).toBe('b1');
     });
 
     it('should preserve execution state during load', async () => {
@@ -469,6 +542,34 @@ describe('useDevScriptsStore', () => {
       // Execution state should remain unchanged
       expect(useDevScriptsStore.getState().executingScriptId).toBe('running_script');
       expect(useDevScriptsStore.getState().activeTerminalSession).toBe('active_session');
+    });
+  });
+
+  // ── selectScriptsForProject ──────────────────────────────────────────
+
+  describe('selectScriptsForProject', () => {
+    it('should return only scripts matching the given projectPath', () => {
+      const scripts = [
+        createMockDevScript({ id: 'a1', projectPath: '/project/a' }),
+        createMockDevScript({ id: 'b1', projectPath: '/project/b' }),
+        createMockDevScript({ id: 'a2', projectPath: '/project/a' }),
+      ];
+
+      const result = selectScriptsForProject(scripts, '/project/a');
+      expect(result).toHaveLength(2);
+      expect(result.every((s) => s.projectPath === '/project/a')).toBe(true);
+    });
+
+    it('should return empty array when no scripts match', () => {
+      const scripts = [createMockDevScript({ id: 'b1', projectPath: '/project/b' })];
+
+      const result = selectScriptsForProject(scripts, '/project/a');
+      expect(result).toHaveLength(0);
+    });
+
+    it('should return empty array for empty input', () => {
+      const result = selectScriptsForProject([], '/project/a');
+      expect(result).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
…overrun (#24)## Summary
- Fixed dev scripts from project A appearing in project B's header buttons and Tool Box when multiple projects are open
- Changed `useDevScriptsStore` from replace to merge semantics so scripts from all projects coexist in the global store
- Added `selectScriptsForProject()` filter used by `DevelopmentScreen` and `DevScriptsTool` to scope scripts by `projectPath`