### PR TITLE
fix(webview): open code-server links in default browser instead of Electron window (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `selectScriptsForProject()` utility for consumer-side filtering by `projectPath`
   - `DevelopmentScreen` header buttons now filter by `contribution.localPath`
   - `DevScriptsTool` script list now filters by `workingDirectory`
+- Fixed links in code-server opening in Electron window instead of user's default browser ([#28](https://github.com/lukadfagundes/cola-records/issues/28))
+  - Added global `app.on('web-contents-created')` handler with `setWindowOpenHandler` to redirect external URLs via `shell.openExternal`
+  - Only `http://` and `https://` protocols are opened externally (security hardening)
 
 ### Tests
 
@@ -66,6 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `DevScriptsTool.test.tsx`: 2 new tests for cross-project script isolation
   - Updated existing "different project paths" test for merge semantics
   - Updated store mocks in 4 DevelopmentScreen test files and ToolsPanel test to export `selectScriptsForProject`
+- Webview external link redirect tests ([#28](https://github.com/lukadfagundes/cola-records/issues/28))
+  - `webview-external-links.test.ts`: 5 tests covering handler registration, http/https redirect, deny action, and non-http protocol blocking
 
 ## [1.0.4] - 2026-02-17
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1282,13 +1282,6 @@ const createWindow = () => {
     }
   });
 
-  // Handle window.open() and target="_blank" links
-  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    // Open all new window requests in the default browser
-    shell.openExternal(url);
-    return { action: 'deny' };
-  });
-
   // Initialize auto-updater (only runs in production)
   updaterService.initialize(mainWindow);
 
@@ -1296,6 +1289,17 @@ const createWindow = () => {
     mainWindow = null;
   });
 };
+
+// Redirect external links from ALL webContents (including code-server webview)
+// to the user's default browser instead of opening Electron windows
+app.on('web-contents-created', (_event, contents) => {
+  contents.setWindowOpenHandler(({ url }) => {
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      shell.openExternal(url);
+    }
+    return { action: 'deny' };
+  });
+});
 
 // This method will be called when Electron has finished initialization
 app.on('ready', async () => {

--- a/tests/main/webview-external-links.test.ts
+++ b/tests/main/webview-external-links.test.ts
@@ -1,0 +1,182 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Track app.on registrations and shell.openExternal calls
+type AppEventCallback = (...args: unknown[]) => void;
+const appOnCalls: Array<{ event: string; callback: AppEventCallback }> = [];
+const mockOpenExternal = vi.fn();
+
+vi.mock('electron', () => ({
+  app: {
+    commandLine: {
+      appendSwitch: vi.fn(),
+    },
+    on: (event: string, cb: AppEventCallback) => {
+      appOnCalls.push({ event, callback: cb });
+    },
+    quit: vi.fn(),
+    getPath: () => '/mock/path',
+    setPath: vi.fn(),
+    isPackaged: false,
+  },
+  BrowserWindow: vi.fn().mockImplementation(() => ({
+    loadURL: vi.fn(),
+    loadFile: vi.fn(),
+    on: vi.fn(),
+    webContents: {
+      openDevTools: vi.fn(),
+      on: vi.fn(),
+    },
+  })),
+  shell: {
+    openExternal: mockOpenExternal,
+  },
+}));
+
+// Mock all services imported by index.ts
+vi.mock('../../src/main/ipc', () => ({
+  handleIpc: vi.fn(),
+  removeAllIpcHandlers: vi.fn(),
+}));
+
+vi.mock('../../src/main/database', () => ({
+  database: {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn(),
+    getAllSettings: vi.fn().mockReturnValue({}),
+    setSetting: vi.fn(),
+    createContribution: vi.fn(),
+    getAllContributions: vi.fn().mockReturnValue([]),
+    getContributionById: vi.fn(),
+    updateContribution: vi.fn(),
+    deleteContribution: vi.fn(),
+    getContributionsByType: vi.fn().mockReturnValue([]),
+  },
+}));
+
+vi.mock('../../src/main/services', () => ({
+  fileSystemService: {},
+  gitService: {},
+  gitIgnoreService: {},
+  gitHubService: {},
+}));
+
+vi.mock('../../src/main/services/github-graphql.service', () => ({
+  gitHubGraphQLService: { resetClient: vi.fn() },
+}));
+
+vi.mock('../../src/main/services/code-server.service', () => ({
+  codeServerService: { stop: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock('../../src/main/services/spotify.service', () => ({
+  spotifyService: { cleanup: vi.fn() },
+}));
+
+vi.mock('../../src/main/services/discord.service', () => ({
+  discordService: { cleanup: vi.fn() },
+}));
+
+vi.mock('../../src/main/workers/scanner-pool', () => ({
+  scannerPool: { terminate: vi.fn() },
+}));
+
+vi.mock('electron-squirrel-startup', () => ({ default: false }));
+
+describe('Webview external link handling', () => {
+  beforeEach(() => {
+    appOnCalls.length = 0;
+    mockOpenExternal.mockClear();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('registers web-contents-created handler on app', async () => {
+    await import('../../src/main/index');
+
+    const handler = appOnCalls.find((c) => c.event === 'web-contents-created');
+    expect(handler).toBeDefined();
+  }, 30000);
+
+  it('calls shell.openExternal for https URLs', async () => {
+    await import('../../src/main/index');
+
+    const handler = appOnCalls.find((c) => c.event === 'web-contents-created');
+    expect(handler).toBeDefined();
+
+    // Simulate webContents creation — the handler calls setWindowOpenHandler on the contents
+    let windowOpenHandler: ((details: { url: string }) => { action: string }) | undefined;
+    const mockContents = {
+      setWindowOpenHandler: (fn: (details: { url: string }) => { action: string }) => {
+        windowOpenHandler = fn;
+      },
+    };
+
+    handler!.callback({}, mockContents);
+    expect(windowOpenHandler).toBeDefined();
+
+    windowOpenHandler!({ url: 'https://github.com/some/repo' });
+    expect(mockOpenExternal).toHaveBeenCalledWith('https://github.com/some/repo');
+  }, 30000);
+
+  it('calls shell.openExternal for http URLs', async () => {
+    await import('../../src/main/index');
+
+    const handler = appOnCalls.find((c) => c.event === 'web-contents-created');
+    let windowOpenHandler: ((details: { url: string }) => { action: string }) | undefined;
+    const mockContents = {
+      setWindowOpenHandler: (fn: (details: { url: string }) => { action: string }) => {
+        windowOpenHandler = fn;
+      },
+    };
+
+    handler!.callback({}, mockContents);
+    windowOpenHandler!({ url: 'http://example.com' });
+    expect(mockOpenExternal).toHaveBeenCalledWith('http://example.com');
+  }, 30000);
+
+  it('denies all new window requests', async () => {
+    await import('../../src/main/index');
+
+    const handler = appOnCalls.find((c) => c.event === 'web-contents-created');
+    let windowOpenHandler: ((details: { url: string }) => { action: string }) | undefined;
+    const mockContents = {
+      setWindowOpenHandler: (fn: (details: { url: string }) => { action: string }) => {
+        windowOpenHandler = fn;
+      },
+    };
+
+    handler!.callback({}, mockContents);
+
+    // All URLs should return deny
+    expect(windowOpenHandler!({ url: 'https://github.com' })).toEqual({ action: 'deny' });
+    expect(windowOpenHandler!({ url: 'http://example.com' })).toEqual({ action: 'deny' });
+    expect(windowOpenHandler!({ url: 'file:///etc/passwd' })).toEqual({ action: 'deny' });
+  }, 30000);
+
+  it('does not call shell.openExternal for non-http protocols', async () => {
+    await import('../../src/main/index');
+
+    const handler = appOnCalls.find((c) => c.event === 'web-contents-created');
+    let windowOpenHandler: ((details: { url: string }) => { action: string }) | undefined;
+    const mockContents = {
+      setWindowOpenHandler: (fn: (details: { url: string }) => { action: string }) => {
+        windowOpenHandler = fn;
+      },
+    };
+
+    handler!.callback({}, mockContents);
+
+    windowOpenHandler!({ url: 'file:///etc/passwd' });
+    expect(mockOpenExternal).not.toHaveBeenCalled();
+
+    windowOpenHandler!({ url: 'javascript:alert(1)' });
+    expect(mockOpenExternal).not.toHaveBeenCalled();
+
+    windowOpenHandler!({ url: 'data:text/html,<h1>test</h1>' });
+    expect(mockOpenExternal).not.toHaveBeenCalled();
+  }, 30000);
+});


### PR DESCRIPTION
## Summary
- Added global `app.on('web-contents-created')` handler that intercepts all webContents (including code-server webview guests) and redirects `http://`/`https://` links to `shell.openExternal`
- Removed redundant per-window `setWindowOpenHandler` now covered by the global handler
- Non-http protocols (`file://`, `javascript:`, etc.) are silently denied for security

## Test plan
- [x] `webview-external-links.test.ts`: 5 new tests (handler registration, http/https redirect, deny action, non-http blocking)
- [x] `electron-gpu-config.test.ts`: no regression
- [x] Typecheck clean