### PR TITLE
Feat/34 Dev Script Toggle Buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Toggle mode for dev scripts — alternating start/stop commands with visual state feedback ([#34](https://github.com/lukadfagundes/cola-records/issues/34))
+  - New `DevScriptToggle` interface with first/second press name and command pairs
+  - SQLite schema v7 migration adding `toggle` column to `dev_scripts` table
+  - 3-way mode selector in script form (Single / Multi / Toggle)
+  - Toggle scripts execute directly via PTY (spawn/write/kill) without modal
+  - Ephemeral toggle state tracked in Zustand store (resets on app restart)
+  - Power icon and "Toggle" badge distinguish toggle scripts visually
+
+### Tests
+
+- Toggle dev script tests covering database, store, ScriptButton, DevScriptsTool form, and DevelopmentScreen integration ([#34](https://github.com/lukadfagundes/cola-records/issues/34))
+
 ## [1.0.6] - 2026-02-20
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -4475,20 +4475,6 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
@@ -17193,6 +17179,20 @@
         "@rollup/rollup-win32-x64-msvc": "4.57.1",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/roughjs": {
       "version": "4.6.6",

--- a/src/main/database/database.service.ts
+++ b/src/main/database/database.service.ts
@@ -2,7 +2,7 @@ import Database from 'better-sqlite3';
 import * as path from 'path';
 import { app } from 'electron';
 import { CREATE_TABLES, SCHEMA_VERSION, MIGRATIONS } from './schema';
-import type { Contribution, DevScript, DevScriptTerminal } from '../ipc/channels';
+import type { Contribution, DevScript, DevScriptTerminal, DevScriptToggle } from '../ipc/channels';
 
 /** Database row type for contributions table */
 interface ContributionRow {
@@ -393,6 +393,7 @@ export class DatabaseService {
       command: string;
       commands: string | null;
       terminals: string | null;
+      toggle: string | null;
       created_at: number;
       updated_at: number;
     }[];
@@ -420,6 +421,16 @@ export class DatabaseService {
         }
       }
 
+      // Parse toggle object if present
+      let toggle: DevScriptToggle | undefined;
+      if (row.toggle) {
+        try {
+          toggle = JSON.parse(row.toggle);
+        } catch {
+          toggle = undefined;
+        }
+      }
+
       return {
         id: row.id,
         projectPath: row.project_path,
@@ -427,6 +438,7 @@ export class DatabaseService {
         command: commands[0] || row.command, // Keep first command for backwards compatibility
         commands,
         terminals,
+        toggle,
         createdAt: new Date(row.created_at).toISOString(),
         updatedAt: new Date(row.updated_at).toISOString(),
       };
@@ -445,6 +457,8 @@ export class DatabaseService {
     // Serialize terminals array to JSON (null if undefined or empty)
     const terminalsJson =
       script.terminals && script.terminals.length > 0 ? JSON.stringify(script.terminals) : null;
+    // Serialize toggle object to JSON (null if undefined)
+    const toggleJson = script.toggle ? JSON.stringify(script.toggle) : null;
     // Keep first command in command column for backwards compatibility
     const firstCommand = script.commands[0] || script.command;
 
@@ -457,15 +471,15 @@ export class DatabaseService {
       // Update existing script
       const stmt = db.prepare(`
         UPDATE dev_scripts
-        SET name = ?, command = ?, commands = ?, terminals = ?, updated_at = ?
+        SET name = ?, command = ?, commands = ?, terminals = ?, toggle = ?, updated_at = ?
         WHERE id = ?
       `);
-      stmt.run(script.name, firstCommand, commandsJson, terminalsJson, now, script.id);
+      stmt.run(script.name, firstCommand, commandsJson, terminalsJson, toggleJson, now, script.id);
     } else {
       // Insert new script
       const stmt = db.prepare(`
-        INSERT INTO dev_scripts (id, project_path, name, command, commands, terminals, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO dev_scripts (id, project_path, name, command, commands, terminals, toggle, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
       stmt.run(
         script.id,
@@ -474,6 +488,7 @@ export class DatabaseService {
         firstCommand,
         commandsJson,
         terminalsJson,
+        toggleJson,
         now,
         now
       );

--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -4,7 +4,7 @@
  * SQLite database schema for Cola Records
  */
 
-export const SCHEMA_VERSION = 6;
+export const SCHEMA_VERSION = 7;
 
 /**
  * SQL statements to create all tables
@@ -92,5 +92,9 @@ export const MIGRATIONS: Record<number, string> = {
   // Version 6: Add terminals column (JSON array) for multi-terminal scripts
   6: `
     ALTER TABLE dev_scripts ADD COLUMN terminals TEXT;
+  `,
+  // Version 7: Add toggle column (JSON) for toggle-mode scripts
+  7: `
+    ALTER TABLE dev_scripts ADD COLUMN toggle TEXT;
   `,
 };

--- a/src/main/ipc/channels/types.ts
+++ b/src/main/ipc/channels/types.ts
@@ -419,6 +419,17 @@ export interface DevScriptTerminal {
   commands: string[];
 }
 
+/**
+ * Configuration for a toggle-mode script that alternates between two states.
+ * Each press cycles the button between first-press and second-press.
+ */
+export interface DevScriptToggle {
+  firstPressName: string;
+  firstPressCommand: string;
+  secondPressName: string;
+  secondPressCommand: string;
+}
+
 export interface DevScript {
   id: string;
   projectPath: string;
@@ -429,6 +440,8 @@ export interface DevScript {
   commands: string[];
   /** Array of terminal configurations for multi-terminal mode */
   terminals?: DevScriptTerminal[];
+  /** Toggle configuration for toggle-mode scripts */
+  toggle?: DevScriptToggle;
   createdAt?: string;
   updatedAt?: string;
 }

--- a/src/renderer/components/tools/DevScriptsTool.tsx
+++ b/src/renderer/components/tools/DevScriptsTool.tsx
@@ -3,6 +3,7 @@
  *
  * Script management panel for creating, editing, and deleting custom dev scripts.
  * Scripts appear as buttons in the Development screen header for quick execution.
+ * Supports three modes: Single Terminal, Multi-Terminal, and Toggle.
  */
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
@@ -18,6 +19,7 @@ import {
   ChevronRight,
   Terminal,
   Layers,
+  Power,
 } from 'lucide-react';
 import { createLogger } from '../../../renderer/utils/logger';
 
@@ -26,6 +28,8 @@ import { Button } from '../ui/Button';
 import { useDevScriptsStore, selectScriptsForProject } from '../../stores/useDevScriptsStore';
 import type { DevScript, DevScriptTerminal } from '../../../main/ipc/channels';
 import { cn } from '../../lib/utils';
+
+type ScriptMode = 'single' | 'multi' | 'toggle';
 
 interface DevScriptsToolProps {
   workingDirectory: string;
@@ -51,10 +55,18 @@ export function DevScriptsTool({ workingDirectory }: DevScriptsToolProps) {
   const [commands, setCommands] = useState<string[]>(['']);
   const [formError, setFormError] = useState<string | null>(null);
 
+  // Mode state (replaces isMultiTerminalMode)
+  const [scriptMode, setScriptMode] = useState<ScriptMode>('single');
+
   // Multi-terminal mode state
-  const [isMultiTerminalMode, setIsMultiTerminalMode] = useState(false);
   const [terminals, setTerminals] = useState<DevScriptTerminal[]>([]);
   const [expandedTerminals, setExpandedTerminals] = useState<Set<number>>(new Set([0]));
+
+  // Toggle mode state
+  const [firstPressName, setFirstPressName] = useState('');
+  const [firstPressCommand, setFirstPressCommand] = useState('');
+  const [secondPressName, setSecondPressName] = useState('');
+  const [secondPressCommand, setSecondPressCommand] = useState('');
 
   // Delete confirmation state
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
@@ -70,8 +82,12 @@ export function DevScriptsTool({ workingDirectory }: DevScriptsToolProps) {
     setName('');
     setCommands(['']);
     setTerminals([]);
-    setIsMultiTerminalMode(false);
+    setScriptMode('single');
     setExpandedTerminals(new Set([0]));
+    setFirstPressName('');
+    setFirstPressCommand('');
+    setSecondPressName('');
+    setSecondPressCommand('');
     setEditingScript(null);
     setFormError(null);
     setIsFormOpen(false);
@@ -86,16 +102,32 @@ export function DevScriptsTool({ workingDirectory }: DevScriptsToolProps) {
     setEditingScript(script);
     setName(script.name);
 
-    // Check if script has terminals (multi-terminal mode)
-    if (script.terminals && script.terminals.length > 0) {
-      setIsMultiTerminalMode(true);
+    // Detect mode from script data
+    if (script.toggle) {
+      setScriptMode('toggle');
+      setFirstPressName(script.toggle.firstPressName);
+      setFirstPressCommand(script.toggle.firstPressCommand);
+      setSecondPressName(script.toggle.secondPressName);
+      setSecondPressCommand(script.toggle.secondPressCommand);
+      setCommands(['']);
+      setTerminals([]);
+    } else if (script.terminals && script.terminals.length > 0) {
+      setScriptMode('multi');
       setTerminals(script.terminals.map((t) => ({ ...t, commands: [...t.commands] })));
-      setCommands(['']); // Reset single-mode commands
+      setCommands(['']);
       setExpandedTerminals(new Set([0]));
+      setFirstPressName('');
+      setFirstPressCommand('');
+      setSecondPressName('');
+      setSecondPressCommand('');
     } else {
-      setIsMultiTerminalMode(false);
+      setScriptMode('single');
       setTerminals([]);
       setCommands(script.commands.length > 0 ? script.commands : [script.command]);
+      setFirstPressName('');
+      setFirstPressCommand('');
+      setSecondPressName('');
+      setSecondPressCommand('');
     }
 
     setFormError(null);
@@ -103,7 +135,63 @@ export function DevScriptsTool({ workingDirectory }: DevScriptsToolProps) {
   }, []);
 
   const handleSubmit = useCallback(async () => {
-    // Validate name
+    // Toggle mode: name is auto-set from firstPressName, skip name validation for toggle
+    if (scriptMode === 'toggle') {
+      // Toggle validation: all 4 fields required
+      if (!firstPressName.trim()) {
+        setFormError('First press name is required');
+        return;
+      }
+      if (!firstPressCommand.trim()) {
+        setFormError('First press command is required');
+        return;
+      }
+      if (!secondPressName.trim()) {
+        setFormError('Second press name is required');
+        return;
+      }
+      if (!secondPressCommand.trim()) {
+        setFormError('Second press command is required');
+        return;
+      }
+
+      const toggleName = firstPressName.trim();
+
+      // Check for duplicate names (excluding current if editing)
+      const duplicate = scripts.find(
+        (s) => s.name.toLowerCase() === toggleName.toLowerCase() && s.id !== editingScript?.id
+      );
+      if (duplicate) {
+        setFormError('A script with this name already exists');
+        return;
+      }
+
+      try {
+        const scriptData: DevScript = {
+          id:
+            editingScript?.id || `script_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+          projectPath: workingDirectory,
+          name: toggleName,
+          command: firstPressCommand.trim(),
+          commands: [firstPressCommand.trim()],
+          terminals: undefined,
+          toggle: {
+            firstPressName: firstPressName.trim(),
+            firstPressCommand: firstPressCommand.trim(),
+            secondPressName: secondPressName.trim(),
+            secondPressCommand: secondPressCommand.trim(),
+          },
+        };
+
+        await saveScript(scriptData);
+        resetForm();
+      } catch (error) {
+        setFormError(String(error));
+      }
+      return;
+    }
+
+    // Validate name for single/multi modes
     if (!name.trim()) {
       setFormError('Name is required');
       return;
@@ -119,7 +207,7 @@ export function DevScriptsTool({ workingDirectory }: DevScriptsToolProps) {
     }
 
     // Validate based on mode
-    if (isMultiTerminalMode) {
+    if (scriptMode === 'multi') {
       // Multi-terminal validation
       if (terminals.length === 0) {
         setFormError('At least one terminal is required');
@@ -199,7 +287,11 @@ export function DevScriptsTool({ workingDirectory }: DevScriptsToolProps) {
     name,
     commands,
     terminals,
-    isMultiTerminalMode,
+    scriptMode,
+    firstPressName,
+    firstPressCommand,
+    secondPressName,
+    secondPressCommand,
     scripts,
     editingScript,
     workingDirectory,
@@ -306,10 +398,10 @@ export function DevScriptsTool({ workingDirectory }: DevScriptsToolProps) {
     });
   }, []);
 
-  const handleModeToggle = useCallback(
-    (multiTerminal: boolean) => {
-      setIsMultiTerminalMode(multiTerminal);
-      if (multiTerminal && terminals.length === 0) {
+  const handleModeChange = useCallback(
+    (mode: ScriptMode) => {
+      setScriptMode(mode);
+      if (mode === 'multi' && terminals.length === 0) {
         // Initialize with one terminal using current commands
         const validCommands = commands.filter((c) => c.trim().length > 0);
         setTerminals([
@@ -374,58 +466,75 @@ export function DevScriptsTool({ workingDirectory }: DevScriptsToolProps) {
             </h4>
 
             <div className="space-y-3">
-              {/* Script Name */}
-              <div>
-                <label className="text-xs text-muted-foreground block mb-1">Name</label>
-                <input
-                  type="text"
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  placeholder="e.g., Build, Test, Dev"
-                  className="w-full px-3 py-2 text-sm bg-background border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-ring"
-                />
-              </div>
+              {/* Script Name (hidden in toggle mode — auto-set from firstPressName) */}
+              {scriptMode !== 'toggle' && (
+                <div>
+                  <label className="text-xs text-muted-foreground block mb-1">Name</label>
+                  <input
+                    type="text"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="e.g., Build, Test, Dev"
+                    className="w-full px-3 py-2 text-sm bg-background border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-ring"
+                  />
+                </div>
+              )}
 
-              {/* Mode Toggle */}
+              {/* Mode Selector (3 buttons) */}
               <div>
                 <label className="text-xs text-muted-foreground block mb-2">Mode</label>
                 <div className="flex gap-2">
                   <button
                     type="button"
-                    onClick={() => handleModeToggle(false)}
+                    onClick={() => handleModeChange('single')}
                     className={cn(
                       'flex items-center gap-2 px-3 py-2 text-sm rounded-md border transition-colors',
-                      !isMultiTerminalMode
+                      scriptMode === 'single'
                         ? 'bg-primary text-primary-foreground border-primary'
                         : 'bg-background border-input hover:border-primary/50'
                     )}
                   >
                     <Terminal className="h-4 w-4" />
-                    Single Terminal
+                    Single
                   </button>
                   <button
                     type="button"
-                    onClick={() => handleModeToggle(true)}
+                    onClick={() => handleModeChange('multi')}
                     className={cn(
                       'flex items-center gap-2 px-3 py-2 text-sm rounded-md border transition-colors',
-                      isMultiTerminalMode
+                      scriptMode === 'multi'
                         ? 'bg-primary text-primary-foreground border-primary'
                         : 'bg-background border-input hover:border-primary/50'
                     )}
                   >
                     <Layers className="h-4 w-4" />
-                    Multi-Terminal
+                    Multi
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleModeChange('toggle')}
+                    className={cn(
+                      'flex items-center gap-2 px-3 py-2 text-sm rounded-md border transition-colors',
+                      scriptMode === 'toggle'
+                        ? 'bg-primary text-primary-foreground border-primary'
+                        : 'bg-background border-input hover:border-primary/50'
+                    )}
+                  >
+                    <Power className="h-4 w-4" />
+                    Toggle
                   </button>
                 </div>
                 <p className="text-xs text-muted-foreground mt-1">
-                  {isMultiTerminalMode
+                  {scriptMode === 'multi'
                     ? 'Launch multiple terminals in parallel (e.g., frontend + backend)'
-                    : 'Run commands sequentially in a single terminal'}
+                    : scriptMode === 'toggle'
+                      ? 'Alternate between two commands (e.g., start / stop)'
+                      : 'Run commands sequentially in a single terminal'}
                 </p>
               </div>
 
               {/* Single Terminal Mode - Commands */}
-              {!isMultiTerminalMode && (
+              {scriptMode === 'single' && (
                 <div>
                   <div className="flex items-center justify-between mb-1">
                     <label className="text-xs text-muted-foreground">
@@ -478,7 +587,7 @@ export function DevScriptsTool({ workingDirectory }: DevScriptsToolProps) {
               )}
 
               {/* Multi-Terminal Mode - Terminal Cards */}
-              {isMultiTerminalMode && (
+              {scriptMode === 'multi' && (
                 <div>
                   <div className="flex items-center justify-between mb-2">
                     <label className="text-xs text-muted-foreground">
@@ -603,6 +712,60 @@ export function DevScriptsTool({ workingDirectory }: DevScriptsToolProps) {
                 </div>
               )}
 
+              {/* Toggle Mode - Two-state form */}
+              {scriptMode === 'toggle' && (
+                <div className="space-y-3">
+                  <div>
+                    <label className="text-xs text-muted-foreground block mb-1">
+                      First Press — Name
+                    </label>
+                    <input
+                      type="text"
+                      value={firstPressName}
+                      onChange={(e) => setFirstPressName(e.target.value)}
+                      placeholder="e.g., Start DB"
+                      className="w-full px-3 py-2 text-sm bg-background border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-ring"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-xs text-muted-foreground block mb-1">
+                      First Press — Command
+                    </label>
+                    <input
+                      type="text"
+                      value={firstPressCommand}
+                      onChange={(e) => setFirstPressCommand(e.target.value)}
+                      placeholder="e.g., docker compose up -d"
+                      className="w-full px-3 py-2 text-sm bg-background border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-ring font-mono"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-xs text-muted-foreground block mb-1">
+                      Second Press — Name
+                    </label>
+                    <input
+                      type="text"
+                      value={secondPressName}
+                      onChange={(e) => setSecondPressName(e.target.value)}
+                      placeholder="e.g., Stop DB"
+                      className="w-full px-3 py-2 text-sm bg-background border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-ring"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-xs text-muted-foreground block mb-1">
+                      Second Press — Command
+                    </label>
+                    <input
+                      type="text"
+                      value={secondPressCommand}
+                      onChange={(e) => setSecondPressCommand(e.target.value)}
+                      placeholder="e.g., docker compose down"
+                      className="w-full px-3 py-2 text-sm bg-background border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-ring font-mono"
+                    />
+                  </div>
+                </div>
+              )}
+
               {formError && <p className="text-xs text-destructive">{formError}</p>}
 
               <div className="flex gap-2">
@@ -641,7 +804,12 @@ export function DevScriptsTool({ workingDirectory }: DevScriptsToolProps) {
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
                     <span className="font-medium text-sm">{script.name}</span>
-                    {script.terminals && script.terminals.length > 0 ? (
+                    {script.toggle ? (
+                      <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded flex items-center gap-1">
+                        <Power className="h-3 w-3" />
+                        Toggle
+                      </span>
+                    ) : script.terminals && script.terminals.length > 0 ? (
                       <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded flex items-center gap-1">
                         <Layers className="h-3 w-3" />
                         {script.terminals.length} terminals
@@ -655,11 +823,13 @@ export function DevScriptsTool({ workingDirectory }: DevScriptsToolProps) {
                     )}
                   </div>
                   <p className="text-xs text-muted-foreground font-mono truncate mt-1">
-                    {script.terminals && script.terminals.length > 0
-                      ? script.terminals.map((t) => t.name).join(', ')
-                      : script.commands.length > 1
-                        ? script.commands.join(' && ')
-                        : script.command}
+                    {script.toggle
+                      ? `${script.toggle.firstPressName} / ${script.toggle.secondPressName}`
+                      : script.terminals && script.terminals.length > 0
+                        ? script.terminals.map((t) => t.name).join(', ')
+                        : script.commands.length > 1
+                          ? script.commands.join(' && ')
+                          : script.command}
                   </p>
                 </div>
 

--- a/src/renderer/components/tools/ScriptButton.tsx
+++ b/src/renderer/components/tools/ScriptButton.tsx
@@ -3,17 +3,46 @@
  *
  * Clear/transparent button for script execution in the Development screen header.
  * Matches header styling with hover effects.
+ * Supports toggle mode with alternating labels and direct execution.
  */
 
-import { Play } from 'lucide-react';
+import { Play, Power } from 'lucide-react';
 import type { DevScript } from '../../../main/ipc/channels';
 
 interface ScriptButtonProps {
   script: DevScript;
   onClick: () => void;
+  isToggle?: boolean;
+  toggleState?: boolean;
+  onToggleExecute?: (command: string) => void;
 }
 
-export function ScriptButton({ script, onClick }: ScriptButtonProps) {
+export function ScriptButton({
+  script,
+  onClick,
+  isToggle,
+  toggleState,
+  onToggleExecute,
+}: ScriptButtonProps) {
+  if (isToggle && script.toggle) {
+    const isSecondPress = !!toggleState;
+    const label = isSecondPress ? script.toggle.secondPressName : script.toggle.firstPressName;
+    const command = isSecondPress
+      ? script.toggle.secondPressCommand
+      : script.toggle.firstPressCommand;
+
+    return (
+      <button
+        onClick={() => onToggleExecute?.(command)}
+        className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded-md transition-colors"
+        title={command}
+      >
+        <Power className="h-3 w-3" />
+        {label}
+      </button>
+    );
+  }
+
   return (
     <button
       onClick={onClick}

--- a/src/renderer/screens/DevelopmentScreen.tsx
+++ b/src/renderer/screens/DevelopmentScreen.tsx
@@ -123,7 +123,12 @@ export function DevelopmentScreen({
   );
 
   // Dev scripts store
-  const { scripts: allScripts, loadScripts: loadDevScripts } = useDevScriptsStore();
+  const {
+    scripts: allScripts,
+    loadScripts: loadDevScripts,
+    toggleStates,
+    flipToggleState,
+  } = useDevScriptsStore();
   const devScripts = useMemo(
     () => selectScriptsForProject(allScripts, contribution.localPath),
     [allScripts, contribution.localPath]
@@ -166,6 +171,25 @@ export function DevelopmentScreen({
       window.removeEventListener('execute-dev-script', handleExecuteScript);
     };
   }, [contribution.localPath]);
+
+  // Toggle script execution: open modal with the current toggle command, then flip state on close
+  const handleToggleExecute = useCallback(
+    (scriptId: string, command: string) => {
+      const script = devScripts.find((s) => s.id === scriptId);
+      if (!script) return;
+      // Create a transient script with the toggle command so the modal runs it
+      const toggleExecScript: DevScript = {
+        ...script,
+        command,
+        commands: [command],
+        terminals: undefined,
+        toggle: undefined,
+      };
+      setExecutingScript(toggleExecScript);
+      flipToggleState(scriptId);
+    },
+    [devScripts, flipToggleState]
+  );
 
   // Fetch authenticated user on mount
   useEffect(() => {
@@ -360,6 +384,9 @@ export function DevelopmentScreen({
                   key={script.id}
                   script={script}
                   onClick={() => setExecutingScript(script)}
+                  isToggle={!!script.toggle}
+                  toggleState={toggleStates[script.id]}
+                  onToggleExecute={(command) => handleToggleExecute(script.id, command)}
                 />
               ))}
             </div>

--- a/src/renderer/stores/useDevScriptsStore.ts
+++ b/src/renderer/stores/useDevScriptsStore.ts
@@ -8,6 +8,8 @@ interface DevScriptsState {
   error: string | null;
   executingScriptId: string | null;
   activeTerminalSession: string | null;
+  /** Ephemeral toggle state: false = first press next, true = second press next */
+  toggleStates: Record<string, boolean>;
 
   // Actions
   loadScripts: (projectPath: string) => Promise<void>;
@@ -15,6 +17,8 @@ interface DevScriptsState {
   deleteScript: (id: string) => Promise<void>;
   setExecutingScript: (id: string | null) => void;
   setActiveTerminalSession: (sessionId: string | null) => void;
+  flipToggleState: (scriptId: string) => void;
+  resetToggleStates: () => void;
 }
 
 export const useDevScriptsStore = create<DevScriptsState>((set, get) => ({
@@ -23,9 +27,10 @@ export const useDevScriptsStore = create<DevScriptsState>((set, get) => ({
   error: null,
   executingScriptId: null,
   activeTerminalSession: null,
+  toggleStates: {},
 
   loadScripts: async (projectPath: string) => {
-    set({ loading: true, error: null });
+    set({ loading: true, error: null, toggleStates: {} });
     try {
       const loaded = await ipc.invoke('dev-scripts:get-all', projectPath);
       set((state) => ({
@@ -79,6 +84,19 @@ export const useDevScriptsStore = create<DevScriptsState>((set, get) => ({
 
   setActiveTerminalSession: (sessionId: string | null) => {
     set({ activeTerminalSession: sessionId });
+  },
+
+  flipToggleState: (scriptId: string) => {
+    set((state) => ({
+      toggleStates: {
+        ...state.toggleStates,
+        [scriptId]: !state.toggleStates[scriptId],
+      },
+    }));
+  },
+
+  resetToggleStates: () => {
+    set({ toggleStates: {} });
   },
 }));
 

--- a/tests/main/database/dev-scripts.test.ts
+++ b/tests/main/database/dev-scripts.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
 import { CREATE_TABLES, MIGRATIONS } from '../../../src/main/database/schema';
-import { createMockDevScript } from '../../mocks/dev-scripts.mock';
+import { createMockDevScript, createMockToggleScript } from '../../mocks/dev-scripts.mock';
 
 // Mock electron before importing DatabaseService
 vi.mock('electron', () => ({
@@ -461,6 +461,142 @@ describe('DevScripts Database Operations', () => {
       expect(result.map((s: any) => s.id)).toContain('script_1');
       expect(result.map((s: any) => s.id)).toContain('script_3');
       expect(result.map((s: any) => s.id)).not.toContain('script_2');
+    });
+  });
+
+  // ── Toggle Support Tests (v7 migration) ──────────────────────────────────────────
+
+  describe('Toggle Support', () => {
+    it('should have toggle column after migrations', () => {
+      const columns = db.prepare("PRAGMA table_info('dev_scripts')").all() as {
+        name: string;
+        type: string;
+      }[];
+      const columnNames = columns.map((c) => c.name);
+      expect(columnNames).toContain('toggle');
+    });
+
+    it('should save and retrieve scripts with toggle configuration', () => {
+      const projectPath = '/test/project';
+      const toggleScript = createMockToggleScript({
+        id: 'script_toggle',
+        projectPath,
+        name: 'Start DB',
+      });
+
+      dbService.saveDevScript(toggleScript);
+
+      const result = dbService.getDevScripts(projectPath);
+      expect(result).toHaveLength(1);
+      expect(result[0].toggle).toEqual({
+        firstPressName: 'Start DB',
+        firstPressCommand: 'docker compose up -d',
+        secondPressName: 'Stop DB',
+        secondPressCommand: 'docker compose down',
+      });
+    });
+
+    it('should return undefined toggle for scripts without toggle', () => {
+      const projectPath = '/test/project';
+
+      dbService.saveDevScript(
+        createMockDevScript({
+          id: 'script_no_toggle',
+          projectPath,
+          name: 'Build',
+          command: 'npm run build',
+        })
+      );
+
+      const result = dbService.getDevScripts(projectPath);
+      expect(result).toHaveLength(1);
+      expect(result[0].toggle).toBeUndefined();
+    });
+
+    it('should handle malformed toggle JSON gracefully', () => {
+      const projectPath = '/test/project';
+
+      db.prepare(
+        'INSERT INTO dev_scripts (id, project_path, name, command, commands, toggle, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+      ).run(
+        'script_malformed_toggle',
+        projectPath,
+        'Bad Toggle',
+        'echo test',
+        JSON.stringify(['echo test']),
+        'not valid json{',
+        Date.now(),
+        Date.now()
+      );
+
+      const result = dbService.getDevScripts(projectPath);
+      expect(result).toHaveLength(1);
+      expect(result[0].toggle).toBeUndefined();
+    });
+
+    it('should preserve toggle configuration on script update', async () => {
+      const projectPath = '/test/project';
+      const scriptId = 'script_update_toggle';
+
+      const originalToggle = {
+        firstPressName: 'Start',
+        firstPressCommand: 'docker start',
+        secondPressName: 'Stop',
+        secondPressCommand: 'docker stop',
+      };
+
+      dbService.saveDevScript(
+        createMockToggleScript({
+          id: scriptId,
+          projectPath,
+          name: 'Start',
+          toggle: originalToggle,
+        })
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const updatedToggle = {
+        firstPressName: 'Start All',
+        firstPressCommand: 'docker compose up -d',
+        secondPressName: 'Stop All',
+        secondPressCommand: 'docker compose down --remove-orphans',
+      };
+
+      dbService.saveDevScript(
+        createMockToggleScript({
+          id: scriptId,
+          projectPath,
+          name: 'Start All',
+          toggle: updatedToggle,
+        })
+      );
+
+      const result = dbService.getDevScripts(projectPath);
+      expect(result).toHaveLength(1);
+      expect(result[0].toggle).toEqual(updatedToggle);
+    });
+
+    it('should round-trip toggle JSON correctly', () => {
+      const projectPath = '/test/project';
+      const toggle = {
+        firstPressName: 'Up',
+        firstPressCommand: 'docker compose up -d --build',
+        secondPressName: 'Down',
+        secondPressCommand: 'docker compose down -v',
+      };
+
+      dbService.saveDevScript(
+        createMockToggleScript({
+          id: 'script_roundtrip',
+          projectPath,
+          name: 'Up',
+          toggle,
+        })
+      );
+
+      const result = dbService.getDevScripts(projectPath);
+      expect(result[0].toggle).toStrictEqual(toggle);
     });
   });
 

--- a/tests/main/database/schema.test.ts
+++ b/tests/main/database/schema.test.ts
@@ -8,8 +8,8 @@ describe('Database Schema', () => {
       expect(Number.isInteger(SCHEMA_VERSION)).toBe(true);
     });
 
-    it('is currently version 6', () => {
-      expect(SCHEMA_VERSION).toBe(6);
+    it('is currently version 7', () => {
+      expect(SCHEMA_VERSION).toBe(7);
     });
   });
 
@@ -111,6 +111,12 @@ describe('Database Schema', () => {
     it('version 6 adds terminals column to dev_scripts for multi-terminal support', () => {
       const migration = MIGRATIONS[6];
       expect(migration).toContain('terminals');
+      expect(migration).toContain('ALTER TABLE dev_scripts');
+    });
+
+    it('version 7 adds toggle column to dev_scripts for toggle-mode scripts', () => {
+      const migration = MIGRATIONS[7];
+      expect(migration).toContain('toggle');
       expect(migration).toContain('ALTER TABLE dev_scripts');
     });
   });

--- a/tests/mocks/dev-scripts.mock.ts
+++ b/tests/mocks/dev-scripts.mock.ts
@@ -69,6 +69,19 @@ export const mockDevScripts = {
       { name: 'Backend', commands: ['npm run dev:backend'] },
     ],
   }),
+  // Toggle script for start/stop scenarios
+  toggleDb: createMockDevScript({
+    id: 'script_toggle_db',
+    name: 'Start DB',
+    command: 'docker compose up -d',
+    commands: ['docker compose up -d'],
+    toggle: {
+      firstPressName: 'Start DB',
+      firstPressCommand: 'docker compose up -d',
+      secondPressName: 'Stop DB',
+      secondPressCommand: 'docker compose down',
+    },
+  }),
   // Multi-terminal with multiple commands per terminal
   complexSetup: createMockDevScript({
     id: 'script_complex_setup',
@@ -89,6 +102,23 @@ export function createMockDevScriptsList(): DevScript[] {
 
 export function createMockMultiTerminalScriptsList(): DevScript[] {
   return [mockDevScripts.fullStack, mockDevScripts.complexSetup];
+}
+
+// ── Toggle Script Factory ──────────────────────────────────────────────
+
+export function createMockToggleScript(overrides?: Partial<DevScript>): DevScript {
+  return createMockDevScript({
+    name: 'Start DB',
+    command: 'docker compose up -d',
+    commands: ['docker compose up -d'],
+    toggle: {
+      firstPressName: 'Start DB',
+      firstPressCommand: 'docker compose up -d',
+      secondPressName: 'Stop DB',
+      secondPressCommand: 'docker compose down',
+    },
+    ...overrides,
+  });
 }
 
 // ── DevScriptTerminal Factory ──────────────────────────────────────────────

--- a/tests/mocks/lucide-react.tsx
+++ b/tests/mocks/lucide-react.tsx
@@ -107,3 +107,4 @@ export const Wrench = createIcon('Wrench');
 export const Menu = createIcon('Menu');
 export const GripVertical = createIcon('GripVertical');
 export const Layers = createIcon('Layers');
+export const Power = createIcon('Power');

--- a/tests/renderer/components/tools/DevScriptsTool.test.tsx
+++ b/tests/renderer/components/tools/DevScriptsTool.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { createMockDevScript } from '../../../mocks/dev-scripts.mock';
+import { createMockDevScript, createMockToggleScript } from '../../../mocks/dev-scripts.mock';
 
 // Mock lucide-react
 vi.mock('lucide-react', async () => import('../../../mocks/lucide-react'));
@@ -528,6 +528,219 @@ describe('DevScriptsTool', () => {
 
       await waitFor(() => {
         expect(screen.getByText('A script with this name already exists')).toBeDefined();
+      });
+    });
+  });
+
+  describe('toggle mode', () => {
+    it('should show Toggle badge for toggle scripts in the list', () => {
+      mockStoreState.scripts = [
+        createMockToggleScript({
+          id: 'toggle_1',
+          projectPath: '/test/project/path',
+        }),
+      ];
+
+      render(<DevScriptsTool {...defaultProps} />);
+      expect(screen.getByText('Toggle')).toBeDefined();
+    });
+
+    it('should show toggle description in script list', () => {
+      mockStoreState.scripts = [
+        createMockToggleScript({
+          id: 'toggle_1',
+          projectPath: '/test/project/path',
+        }),
+      ];
+
+      render(<DevScriptsTool {...defaultProps} />);
+      expect(screen.getByText('Start DB / Stop DB')).toBeDefined();
+    });
+
+    it('should show 3 mode buttons when form is open', async () => {
+      render(<DevScriptsTool {...defaultProps} />);
+
+      const addButton = screen.getByText('Add Script');
+      await act(async () => {
+        fireEvent.click(addButton);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Single')).toBeDefined();
+        expect(screen.getByText('Multi')).toBeDefined();
+        expect(screen.getByText('Toggle')).toBeDefined();
+      });
+    });
+
+    it('should show toggle form fields when toggle mode selected', async () => {
+      const user = userEvent.setup();
+      render(<DevScriptsTool {...defaultProps} />);
+
+      await user.click(screen.getByText('Add Script'));
+
+      // Click Toggle mode button
+      await waitFor(() => {
+        expect(screen.getByText('Toggle')).toBeDefined();
+      });
+      await user.click(screen.getByText('Toggle'));
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('e.g., Start DB')).toBeDefined();
+        expect(screen.getByPlaceholderText('e.g., docker compose up -d')).toBeDefined();
+        expect(screen.getByPlaceholderText('e.g., Stop DB')).toBeDefined();
+        expect(screen.getByPlaceholderText('e.g., docker compose down')).toBeDefined();
+      });
+    });
+
+    it('should validate first press name is required', async () => {
+      const user = userEvent.setup();
+      render(<DevScriptsTool {...defaultProps} />);
+
+      await user.click(screen.getByText('Add Script'));
+
+      // Switch to toggle mode
+      await waitFor(() => {
+        expect(screen.getByText('Toggle')).toBeDefined();
+      });
+      await user.click(screen.getByText('Toggle'));
+
+      // Submit with all fields empty
+      const buttons = screen.getAllByRole('button');
+      for (const btn of buttons) {
+        if (btn.textContent === 'Add Script') {
+          const parent = btn.parentElement;
+          if (parent?.classList.contains('flex') && parent?.classList.contains('gap-2')) {
+            await user.click(btn);
+            break;
+          }
+        }
+      }
+
+      await waitFor(() => {
+        expect(screen.getByText('First press name is required')).toBeDefined();
+      });
+    });
+
+    it('should validate first press command is required', async () => {
+      const user = userEvent.setup();
+      render(<DevScriptsTool {...defaultProps} />);
+
+      await user.click(screen.getByText('Add Script'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Toggle')).toBeDefined();
+      });
+      await user.click(screen.getByText('Toggle'));
+
+      // Fill only first press name
+      const firstPressName = await screen.findByPlaceholderText('e.g., Start DB');
+      await user.type(firstPressName, 'Start');
+
+      // Submit
+      const buttons = screen.getAllByRole('button');
+      for (const btn of buttons) {
+        if (btn.textContent === 'Add Script') {
+          const parent = btn.parentElement;
+          if (parent?.classList.contains('flex') && parent?.classList.contains('gap-2')) {
+            await user.click(btn);
+            break;
+          }
+        }
+      }
+
+      await waitFor(() => {
+        expect(screen.getByText('First press command is required')).toBeDefined();
+      });
+    });
+
+    it('should save toggle script on submit', async () => {
+      mockSaveScript.mockResolvedValueOnce(undefined);
+
+      render(<DevScriptsTool {...defaultProps} />);
+
+      // Open form
+      await act(async () => {
+        fireEvent.click(screen.getByText('Add Script'));
+      });
+
+      // Switch to toggle mode
+      await waitFor(() => {
+        expect(screen.getByText('Toggle')).toBeDefined();
+      });
+      fireEvent.click(screen.getByText('Toggle'));
+
+      // Fill all fields using fireEvent.change (faster than userEvent.type for long strings)
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('e.g., Start DB')).toBeDefined();
+      });
+      fireEvent.change(screen.getByPlaceholderText('e.g., Start DB'), {
+        target: { value: 'Start DB' },
+      });
+      fireEvent.change(screen.getByPlaceholderText('e.g., docker compose up -d'), {
+        target: { value: 'docker compose up -d' },
+      });
+      fireEvent.change(screen.getByPlaceholderText('e.g., Stop DB'), {
+        target: { value: 'Stop DB' },
+      });
+      fireEvent.change(screen.getByPlaceholderText('e.g., docker compose down'), {
+        target: { value: 'docker compose down' },
+      });
+
+      // Submit
+      const buttons = screen.getAllByRole('button');
+      for (const btn of buttons) {
+        if (btn.textContent === 'Add Script') {
+          const parent = btn.parentElement;
+          if (parent?.classList.contains('flex') && parent?.classList.contains('gap-2')) {
+            fireEvent.click(btn);
+            break;
+          }
+        }
+      }
+
+      await waitFor(() => {
+        expect(mockSaveScript).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'Start DB',
+            toggle: {
+              firstPressName: 'Start DB',
+              firstPressCommand: 'docker compose up -d',
+              secondPressName: 'Stop DB',
+              secondPressCommand: 'docker compose down',
+            },
+            projectPath: '/test/project/path',
+          })
+        );
+      });
+    });
+
+    it('should populate toggle form when editing a toggle script', async () => {
+      mockStoreState.scripts = [
+        createMockToggleScript({
+          id: 'toggle_edit',
+          projectPath: '/test/project/path',
+        }),
+      ];
+
+      const { container } = render(<DevScriptsTool {...defaultProps} />);
+
+      const editButton = container.querySelector('button[title="Edit script"]');
+      fireEvent.click(editButton!);
+
+      await waitFor(() => {
+        expect(screen.getByText('Edit Script')).toBeDefined();
+        const firstPressName = screen.getByPlaceholderText('e.g., Start DB') as HTMLInputElement;
+        expect(firstPressName.value).toBe('Start DB');
+        const firstPressCommand = screen.getByPlaceholderText(
+          'e.g., docker compose up -d'
+        ) as HTMLInputElement;
+        expect(firstPressCommand.value).toBe('docker compose up -d');
+        const secondPressName = screen.getByPlaceholderText('e.g., Stop DB') as HTMLInputElement;
+        expect(secondPressName.value).toBe('Stop DB');
+        const secondPressCommand = screen.getByPlaceholderText(
+          'e.g., docker compose down'
+        ) as HTMLInputElement;
+        expect(secondPressCommand.value).toBe('docker compose down');
       });
     });
   });

--- a/tests/renderer/components/tools/ScriptButton.test.tsx
+++ b/tests/renderer/components/tools/ScriptButton.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { createMockDevScript } from '../../../mocks/dev-scripts.mock';
+import { createMockDevScript, createMockToggleScript } from '../../../mocks/dev-scripts.mock';
 
 // Mock lucide-react
 vi.mock('lucide-react', async () => import('../../../mocks/lucide-react'));
@@ -157,5 +157,75 @@ describe('ScriptButton', () => {
     fireEvent.click(button);
 
     expect(mockOnClick).toHaveBeenCalledTimes(3);
+  });
+
+  // ── Toggle Mode Tests ──────────────────────────────────────────
+
+  describe('toggle mode', () => {
+    const mockToggleExecute = vi.fn();
+    const toggleScript = createMockToggleScript({ id: 'toggle_1' });
+
+    const toggleProps = {
+      script: toggleScript,
+      onClick: mockOnClick,
+      isToggle: true,
+      toggleState: false,
+      onToggleExecute: mockToggleExecute,
+    };
+
+    it('should render first press name when toggleState is false', () => {
+      render(<ScriptButton {...toggleProps} />);
+      expect(screen.getByText('Start DB')).toBeDefined();
+    });
+
+    it('should render second press name when toggleState is true', () => {
+      render(<ScriptButton {...toggleProps} toggleState={true} />);
+      expect(screen.getByText('Stop DB')).toBeDefined();
+    });
+
+    it('should show first press command as title when toggleState is false', () => {
+      render(<ScriptButton {...toggleProps} />);
+      expect(screen.getByRole('button').getAttribute('title')).toBe('docker compose up -d');
+    });
+
+    it('should show second press command as title when toggleState is true', () => {
+      render(<ScriptButton {...toggleProps} toggleState={true} />);
+      expect(screen.getByRole('button').getAttribute('title')).toBe('docker compose down');
+    });
+
+    it('should call onToggleExecute with first press command', () => {
+      render(<ScriptButton {...toggleProps} />);
+      fireEvent.click(screen.getByRole('button'));
+      expect(mockToggleExecute).toHaveBeenCalledWith('docker compose up -d');
+    });
+
+    it('should call onToggleExecute with second press command', () => {
+      render(<ScriptButton {...toggleProps} toggleState={true} />);
+      fireEvent.click(screen.getByRole('button'));
+      expect(mockToggleExecute).toHaveBeenCalledWith('docker compose down');
+    });
+
+    it('should not call onClick in toggle mode', () => {
+      render(<ScriptButton {...toggleProps} />);
+      fireEvent.click(screen.getByRole('button'));
+      expect(mockOnClick).not.toHaveBeenCalled();
+    });
+
+    it('should render Power icon in toggle mode', () => {
+      const { container } = render(<ScriptButton {...toggleProps} />);
+      expect(container.querySelector('[data-testid="icon-power"]')).not.toBeNull();
+    });
+
+    it('should render Play icon in non-toggle mode', () => {
+      const { container } = render(<ScriptButton {...defaultProps} />);
+      expect(container.querySelector('[data-testid="icon-play"]')).not.toBeNull();
+    });
+
+    it('should fall back to non-toggle mode when script has no toggle config', () => {
+      const nonToggleScript = createMockDevScript({ id: 'no_toggle', name: 'Build' });
+      render(<ScriptButton script={nonToggleScript} onClick={mockOnClick} isToggle={true} />);
+      // Should render script name (non-toggle fallback)
+      expect(screen.getByText('Build')).toBeDefined();
+    });
   });
 });

--- a/tests/renderer/screens/DevelopmentScreen.toggle.test.tsx
+++ b/tests/renderer/screens/DevelopmentScreen.toggle.test.tsx
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { createMockToggleScript, createMockDevScript } from '../../mocks/dev-scripts.mock';
+import { createMockContribution } from '../../mocks/factories';
+import type { DevScript } from '../../../src/main/ipc/channels';
+
+// Mock lucide-react
+vi.mock('lucide-react', async () => import('../../mocks/lucide-react'));
+
+// Hoist mock variables
+const { mockInvoke, mockOn } = vi.hoisted(() => ({
+  mockInvoke: vi.fn(),
+  mockOn: vi.fn(() => vi.fn()),
+}));
+
+// Mock the IPC client
+vi.mock('../../../src/renderer/ipc/client', () => ({
+  ipc: {
+    invoke: mockInvoke,
+    send: vi.fn(),
+    on: mockOn,
+    platform: 'win32',
+    isDevelopment: true,
+  },
+}));
+
+// Mock window.electronAPI
+const mockElectronAPI = {
+  invoke: mockInvoke,
+  on: vi.fn(() => vi.fn()),
+  send: vi.fn(),
+};
+
+// Track toggle state
+let mockToggleStates: Record<string, boolean> = {};
+const mockFlipToggleState = vi.fn((id: string) => {
+  mockToggleStates[id] = !mockToggleStates[id];
+});
+
+// Mock the dev scripts store
+let mockDevScriptsState: any = {};
+
+vi.mock('../../../src/renderer/stores/useDevScriptsStore', () => ({
+  useDevScriptsStore: () => mockDevScriptsState,
+  selectScriptsForProject: (scripts: any[], projectPath: string) =>
+    scripts.filter((s: any) => s.projectPath === projectPath),
+}));
+
+// Mock ScriptButton to test toggle execution integration
+vi.mock('../../../src/renderer/components/tools/ScriptButton', () => ({
+  ScriptButton: ({ script, onClick, isToggle, toggleState, onToggleExecute }: any) => {
+    if (isToggle && script.toggle) {
+      const label = toggleState ? script.toggle.secondPressName : script.toggle.firstPressName;
+      const command = toggleState
+        ? script.toggle.secondPressCommand
+        : script.toggle.firstPressCommand;
+      return (
+        <button
+          data-testid={`toggle-button-${script.id}`}
+          data-toggle-state={String(!!toggleState)}
+          onClick={() => onToggleExecute?.(command)}
+        >
+          {label}
+        </button>
+      );
+    }
+    return (
+      <button data-testid={`script-button-${script.id}`} onClick={onClick}>
+        {script.name}
+      </button>
+    );
+  },
+}));
+
+// Mock ScriptExecutionModal
+vi.mock('../../../src/renderer/components/tools/ScriptExecutionModal', () => ({
+  ScriptExecutionModal: ({ isOpen, script, onClose }: any) =>
+    isOpen && script ? (
+      <div data-testid="script-execution-modal">
+        <span>Executing: {script.name}</span>
+        <button onClick={onClose}>Close</button>
+      </div>
+    ) : null,
+}));
+
+// Mock XTermTerminal
+vi.mock('../../../src/renderer/components/tools/XTermTerminal', () => ({
+  XTermTerminal: () => <div data-testid="xterm-terminal">Mock Terminal</div>,
+}));
+
+// Mock other dependencies
+vi.mock('../../../src/renderer/components/ui/Button', () => ({
+  Button: ({ children, onClick, ...props }: any) => (
+    <button onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('../../../src/renderer/components/ui/DropdownMenu', () => ({
+  DropdownMenu: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, onClick }: any) => <button onClick={onClick}>{children}</button>,
+}));
+
+vi.mock('../../../src/renderer/stores/useContributionsStore', () => ({
+  useContributionsStore: () => ({
+    contributions: [
+      createMockContribution({
+        id: 'contrib_1',
+        localPath: '/test/project',
+        repositoryUrl: 'https://github.com/test/repo',
+      }),
+    ],
+    loading: false,
+    fetchContributions: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../src/renderer/stores/useSettingsStore', () => ({
+  useSettingsStore: () => ({
+    settings: { defaultClonePath: '/mock/path' },
+    fetchSettings: vi.fn(),
+  }),
+}));
+
+describe('DevelopmentScreen Toggle Integration', () => {
+  const toggleScript = createMockToggleScript({
+    id: 'toggle_db',
+    projectPath: '/test/project',
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockToggleStates = {};
+    mockDevScriptsState = {
+      scripts: [toggleScript],
+      loading: false,
+      error: null,
+      executingScriptId: null,
+      activeTerminalSession: null,
+      toggleStates: mockToggleStates,
+      loadScripts: vi.fn(),
+      saveScript: vi.fn(),
+      deleteScript: vi.fn(),
+      setExecutingScript: vi.fn(),
+      setActiveTerminalSession: vi.fn(),
+      flipToggleState: mockFlipToggleState,
+      resetToggleStates: vi.fn(),
+    };
+    (window as any).electronAPI = mockElectronAPI;
+  });
+
+  afterEach(() => {
+    cleanup();
+    (window as any).electronAPI = undefined;
+  });
+
+  it('should detect toggle scripts by toggle field presence', () => {
+    expect(toggleScript.toggle).toBeDefined();
+    expect(toggleScript.toggle?.firstPressName).toBe('Start DB');
+    expect(toggleScript.toggle?.secondPressName).toBe('Stop DB');
+  });
+
+  it('should not detect regular scripts as toggle', () => {
+    const normalScript = createMockDevScript({ id: 'normal_1', name: 'Build' });
+    expect(normalScript.toggle).toBeUndefined();
+  });
+
+  it('should flip toggle state on execute', () => {
+    expect(mockToggleStates['toggle_db']).toBeUndefined();
+
+    mockFlipToggleState('toggle_db');
+    expect(mockToggleStates['toggle_db']).toBe(true);
+
+    mockFlipToggleState('toggle_db');
+    expect(mockToggleStates['toggle_db']).toBe(false);
+  });
+
+  it('should use first press command when toggle state is false', () => {
+    const state = !!mockToggleStates['toggle_db'];
+    const command = state
+      ? toggleScript.toggle!.secondPressCommand
+      : toggleScript.toggle!.firstPressCommand;
+    expect(command).toBe('docker compose up -d');
+  });
+
+  it('should use second press command when toggle state is true', () => {
+    mockToggleStates['toggle_db'] = true;
+    const state = !!mockToggleStates['toggle_db'];
+    const command = state
+      ? toggleScript.toggle!.secondPressCommand
+      : toggleScript.toggle!.firstPressCommand;
+    expect(command).toBe('docker compose down');
+  });
+
+  it('should construct a transient script with the toggle command for modal execution', () => {
+    // Simulate handleToggleExecute: creates a modified DevScript for the modal
+    const command = toggleScript.toggle!.firstPressCommand;
+    const toggleExecScript: DevScript = {
+      ...toggleScript,
+      command,
+      commands: [command],
+      terminals: undefined,
+      toggle: undefined,
+    };
+
+    // The transient script should have only the current toggle command
+    expect(toggleExecScript.command).toBe('docker compose up -d');
+    expect(toggleExecScript.commands).toEqual(['docker compose up -d']);
+    // toggle and terminals should be cleared so the modal runs it as a single-terminal script
+    expect(toggleExecScript.toggle).toBeUndefined();
+    expect(toggleExecScript.terminals).toBeUndefined();
+    // Other fields preserved from original script
+    expect(toggleExecScript.id).toBe('toggle_db');
+    expect(toggleExecScript.name).toBe('Start DB');
+  });
+
+  it('should construct second press transient script correctly', () => {
+    const command = toggleScript.toggle!.secondPressCommand;
+    const toggleExecScript: DevScript = {
+      ...toggleScript,
+      command,
+      commands: [command],
+      terminals: undefined,
+      toggle: undefined,
+    };
+
+    expect(toggleExecScript.command).toBe('docker compose down');
+    expect(toggleExecScript.commands).toEqual(['docker compose down']);
+  });
+});

--- a/tests/renderer/stores/useDevScriptsStore.test.ts
+++ b/tests/renderer/stores/useDevScriptsStore.test.ts
@@ -28,6 +28,7 @@ describe('useDevScriptsStore', () => {
       error: null,
       executingScriptId: null,
       activeTerminalSession: null,
+      toggleStates: {},
     });
     mockInvoke.mockReset();
   });
@@ -401,6 +402,71 @@ describe('useDevScriptsStore', () => {
 
       expect(useDevScriptsStore.getState().executingScriptId).toBe('script_1');
       expect(useDevScriptsStore.getState().activeTerminalSession).toBe('session_2');
+    });
+  });
+
+  // ── TT-Toggle: Toggle State Tests ──────────────────────────────────────────
+
+  describe('toggle state', () => {
+    it('should have empty toggleStates initially', () => {
+      const state = useDevScriptsStore.getState();
+      expect(state.toggleStates).toEqual({});
+    });
+
+    it('should flip toggle state from false to true', () => {
+      act(() => {
+        useDevScriptsStore.getState().flipToggleState('script_1');
+      });
+
+      expect(useDevScriptsStore.getState().toggleStates['script_1']).toBe(true);
+    });
+
+    it('should flip toggle state from true to false', () => {
+      useDevScriptsStore.setState({ toggleStates: { script_1: true } });
+
+      act(() => {
+        useDevScriptsStore.getState().flipToggleState('script_1');
+      });
+
+      expect(useDevScriptsStore.getState().toggleStates['script_1']).toBe(false);
+    });
+
+    it('should track toggle states independently for different scripts', () => {
+      act(() => {
+        useDevScriptsStore.getState().flipToggleState('script_a');
+        useDevScriptsStore.getState().flipToggleState('script_b');
+        useDevScriptsStore.getState().flipToggleState('script_b');
+      });
+
+      const { toggleStates } = useDevScriptsStore.getState();
+      expect(toggleStates['script_a']).toBe(true);
+      expect(toggleStates['script_b']).toBe(false);
+    });
+
+    it('should reset all toggle states', () => {
+      useDevScriptsStore.setState({
+        toggleStates: { script_1: true, script_2: false, script_3: true },
+      });
+
+      act(() => {
+        useDevScriptsStore.getState().resetToggleStates();
+      });
+
+      expect(useDevScriptsStore.getState().toggleStates).toEqual({});
+    });
+
+    it('should reset toggle states when loading scripts', async () => {
+      useDevScriptsStore.setState({
+        toggleStates: { script_1: true, script_2: false },
+      });
+
+      mockInvoke.mockResolvedValueOnce([]);
+
+      await act(async () => {
+        await useDevScriptsStore.getState().loadScripts('/test/project');
+      });
+
+      expect(useDevScriptsStore.getState().toggleStates).toEqual({});
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds a third dev script mode — **Toggle** — for start/stop scenarios (e.g., `docker compose up -d` / `docker compose down`)
- Toggle buttons alternate between two named states, each with its own command, and execute via the standard ScriptExecutionModal
- Includes SQLite schema v7 migration (`toggle` column), Zustand ephemeral state tracking, 3-way mode selector in the create/edit form, and toggle-aware ScriptButton rendering