### PR TITLE
Fix/36 Actions Tool Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Actions tool now displays the workflow name for each run in the list view and run detail summary ([#36](https://github.com/lukadfagundes/cola-records/issues/36))
+
+### Tests
+
+- Added tests for workflow name visibility in Actions tool list view and run detail view ([#36](https://github.com/lukadfagundes/cola-records/issues/36))
+
 ## [1.0.7] - 2026-02-20
 
 ### Added

--- a/src/renderer/components/tools/ActionsTool.tsx
+++ b/src/renderer/components/tools/ActionsTool.tsx
@@ -292,6 +292,9 @@ export function ActionsTool({ contribution }: ActionsToolProps) {
             </div>
             <div className="text-xs text-muted-foreground space-y-0.5">
               <div>
+                Workflow: <span className="text-foreground">{selectedRun.name}</span>
+              </div>
+              <div>
                 Branch: <span className="text-foreground">{selectedRun.headBranch}</span>
               </div>
               <div>
@@ -423,6 +426,7 @@ export function ActionsTool({ contribution }: ActionsToolProps) {
                   {getStatusLabel(run.status, run.conclusion)}
                 </span>
                 <div className="min-w-0 flex-1">
+                  <div className="text-[11px] text-muted-foreground truncate">{run.name}</div>
                   <div className="flex items-center gap-1.5">
                     <span className="font-medium text-sm truncate">{run.displayTitle}</span>
                     <span className="text-muted-foreground shrink-0">#{run.runNumber}</span>

--- a/tests/renderer/components/tools/ActionsTool.test.tsx
+++ b/tests/renderer/components/tools/ActionsTool.test.tsx
@@ -131,6 +131,17 @@ describe('ActionsTool', () => {
       });
     });
 
+    it('shows workflow name for each run', async () => {
+      setupMocks();
+      render(<ActionsTool {...defaultProps} />);
+
+      await waitFor(() => {
+        const ciLabels = screen.getAllByText('CI');
+        expect(ciLabels.length).toBe(2); // Two runs with workflow name "CI"
+        expect(screen.getByText('Deploy')).toBeDefined();
+      });
+    });
+
     it('shows run count after loading', async () => {
       setupMocks();
       render(<ActionsTool {...defaultProps} />);
@@ -259,6 +270,22 @@ describe('ActionsTool', () => {
       await waitFor(() => {
         expect(screen.getByText('abc123d')).toBeDefined(); // truncated sha
         expect(screen.getByText('#42')).toBeDefined();
+      });
+    });
+
+    it('shows workflow name in run summary', async () => {
+      const user = userEvent.setup();
+      setupMocks();
+      render(<ActionsTool {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Fix tests')).toBeDefined();
+      });
+
+      await user.click(screen.getByText('Fix tests'));
+
+      await waitFor(() => {
+        expect(screen.getByText('CI')).toBeDefined(); // Workflow name in summary
       });
     });
 


### PR DESCRIPTION
# Summary

- Actions tool now shows the **workflow name** (e.g. "CI", "Checkpoint", "CodeQL Analysis") for each run in the list view and run detail summary
- The `name` field was already fetched from the GitHub API but never rendered — this fix surfaces it in the UI