### PR TITLE
Fix/37 Push Issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- GIT_ASKPASS credential helper for Tool Box Terminal — Git operations (`push`, `pull`, `fetch`) now authenticate automatically using the app's stored GitHub token ([#37](https://github.com/lukadfagundes/cola-records/issues/37))
+  - Platform-specific askpass script (`.sh` on Unix, `.bat` on Windows) using the `x-access-token` pattern
+  - Token stored in separate file with 0o600 permissions — script contains no secrets
+  - Token file updates immediately when GitHub token changes in Settings
+  - Automatic cleanup of askpass files on app quit
+
 ### Fixed
 
 - Actions tool now displays the workflow name for each run in the list view and run detail summary ([#36](https://github.com/lukadfagundes/cola-records/issues/36))
 
 ### Tests
 
+- GIT_ASKPASS service tests covering initialization, platform script generation, token file management, env var injection, and cleanup ([#37](https://github.com/lukadfagundes/cola-records/issues/37))
+- Terminal service tests for GIT_ASKPASS env var injection into PTY spawn ([#37](https://github.com/lukadfagundes/cola-records/issues/37))
 - Added tests for workflow name visibility in Actions tool list view and run detail view ([#36](https://github.com/lukadfagundes/cola-records/issues/36))
 
 ## [1.0.7] - 2026-02-20

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import { spotifyService } from './services/spotify.service';
 import { discordService } from './services/discord.service';
 import { scannerPool } from './workers/scanner-pool';
 import { updaterService } from './services/updater.service';
+import { gitAskPassService } from './services/git-askpass.service';
 
 // Use separate user data directory in development to avoid cache conflicts with production
 if (!app.isPackaged) {
@@ -97,6 +98,7 @@ app.on('web-contents-created', (_event, contents) => {
 // This method will be called when Electron has finished initialization
 app.on('ready', async () => {
   await initializeServices();
+  gitAskPassService.initialize();
   setupIpcHandlers();
   createWindow();
 });
@@ -127,6 +129,7 @@ async function cleanup(): Promise<void> {
     // Cleanup stop failure is non-critical
   }
   terminalService.cleanup();
+  gitAskPassService.cleanup();
   spotifyService.cleanup();
   discordService.cleanup();
   scannerPool.terminate();

--- a/src/main/ipc/handlers/settings.handlers.ts
+++ b/src/main/ipc/handlers/settings.handlers.ts
@@ -117,6 +117,9 @@ export function setupSettingsHandlers(): void {
       // Sync token to ~/.git-credentials for code-server authentication
       const { gitService } = await import('../../services');
       gitService.syncTokenToGitCredentials(updates.githubToken || null);
+      // Update askpass token file for terminal Git authentication
+      const { gitAskPassService } = await import('../../services/git-askpass.service');
+      gitAskPassService.updateToken(updates.githubToken || null);
     }
     if (updates.theme !== undefined) {
       database.setSetting('theme', updates.theme);

--- a/src/main/services/git-askpass.service.ts
+++ b/src/main/services/git-askpass.service.ts
@@ -1,0 +1,195 @@
+/**
+ * GitAskPassService
+ *
+ * Manages a GIT_ASKPASS helper script and token file so that Git operations
+ * in the Tool Box Terminal (PTY) authenticate automatically using the app's
+ * stored GitHub token. This is the same pattern VS Code uses.
+ *
+ * Flow:
+ * 1. On app startup → write platform-specific askpass script + token file
+ * 2. Terminal PTY spawn() includes GIT_ASKPASS env var pointing to the script
+ * 3. When Git needs credentials, it runs the script which reads the token file
+ * 4. On app quit → clean up all files
+ *
+ * Security:
+ * - Token file has 0o600 permissions (owner read/write only)
+ * - Script file has 0o755 permissions (owner rwx, others rx — needed for Git to execute)
+ * - Script contains NO secrets — only reads from the token file
+ * - Files stored in app.getPath('userData')/git-askpass/
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { app } from 'electron';
+import { database } from '../database';
+import { env } from './environment.service';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('GitAskPass');
+
+class GitAskPassService {
+  private askpassDir: string = '';
+  private scriptPath: string = '';
+  private tokenPath: string = '';
+  private initialized = false;
+
+  /**
+   * Initialize the askpass service: create directory, write script and token file.
+   * Called once on app startup after database is initialized.
+   */
+  initialize(): void {
+    try {
+      this.askpassDir = path.join(app.getPath('userData'), 'git-askpass');
+      this.tokenPath = path.join(this.askpassDir, 'git-token.txt');
+
+      const isWindows = process.platform === 'win32';
+      this.scriptPath = path.join(
+        this.askpassDir,
+        isWindows ? 'git-askpass.bat' : 'git-askpass.sh'
+      );
+
+      // Create directory
+      if (!fs.existsSync(this.askpassDir)) {
+        fs.mkdirSync(this.askpassDir, { recursive: true });
+      }
+
+      // Write platform-specific script
+      this.writeScript();
+
+      // Write token file from current settings
+      const token = this.getCurrentToken();
+      if (token) {
+        this.writeTokenFile(token);
+      }
+
+      this.initialized = true;
+      logger.info('Initialized askpass helper', this.askpassDir);
+    } catch (error) {
+      logger.warn('Failed to initialize askpass helper', error);
+    }
+  }
+
+  /**
+   * Get env vars to inject into PTY spawn.
+   * Returns empty object if no token is configured or service not initialized.
+   */
+  getAskPassEnv(): Record<string, string> {
+    if (!this.initialized || !fs.existsSync(this.tokenPath)) {
+      return {};
+    }
+
+    return {
+      GIT_ASKPASS: this.scriptPath,
+      GIT_TERMINAL_PROMPT: '0',
+    };
+  }
+
+  /**
+   * Update the token file when settings change.
+   * Pass null to remove the token file.
+   */
+  updateToken(token: string | null): void {
+    if (!this.initialized) return;
+
+    try {
+      if (token) {
+        this.writeTokenFile(token);
+        logger.debug('Token file updated');
+      } else {
+        if (fs.existsSync(this.tokenPath)) {
+          fs.unlinkSync(this.tokenPath);
+          logger.debug('Token file removed');
+        }
+      }
+    } catch (error) {
+      logger.warn('Failed to update token file', error);
+    }
+  }
+
+  /**
+   * Remove all askpass files on app quit.
+   */
+  cleanup(): void {
+    try {
+      if (this.askpassDir && fs.existsSync(this.askpassDir)) {
+        fs.rmSync(this.askpassDir, { recursive: true, force: true });
+        logger.debug('Cleaned up askpass directory');
+      }
+    } catch (error) {
+      logger.warn('Failed to clean up askpass directory', error);
+    }
+    this.initialized = false;
+  }
+
+  /**
+   * Write the platform-specific GIT_ASKPASS script.
+   * The script responds to Git's credential prompts:
+   * - Username prompt → "x-access-token"
+   * - Password prompt → reads token from file
+   */
+  private writeScript(): void {
+    const isWindows = process.platform === 'win32';
+    const tokenFilePath = this.tokenPath;
+
+    const content = isWindows
+      ? this.getWindowsScript(tokenFilePath)
+      : this.getUnixScript(tokenFilePath);
+
+    fs.writeFileSync(this.scriptPath, content, {
+      mode: isWindows ? 0o755 : 0o755,
+    });
+  }
+
+  private getWindowsScript(tokenFilePath: string): string {
+    // Normalize to Windows backslashes for the batch file
+    const winTokenPath = tokenFilePath.replace(/\//g, '\\');
+    return [
+      '@echo off',
+      'setlocal',
+      'echo %1 | findstr /i "username" >nul',
+      'if %errorlevel% equ 0 (',
+      '  echo x-access-token',
+      '  exit /b 0',
+      ')',
+      `if exist "${winTokenPath}" (`,
+      `  set /p TOKEN=<"${winTokenPath}"`,
+      '  echo %TOKEN%',
+      ') else (',
+      '  echo.',
+      ')',
+      '',
+    ].join('\r\n');
+  }
+
+  private getUnixScript(tokenFilePath: string): string {
+    return [
+      '#!/bin/sh',
+      `case "$1" in`,
+      '  *sername*)',
+      '    echo "x-access-token"',
+      '    ;;',
+      '  *)',
+      `    if [ -f "${tokenFilePath}" ]; then`,
+      `      cat "${tokenFilePath}"`,
+      '    fi',
+      '    ;;',
+      'esac',
+      '',
+    ].join('\n');
+  }
+
+  private writeTokenFile(token: string): void {
+    fs.writeFileSync(this.tokenPath, token, { mode: 0o600 });
+  }
+
+  private getCurrentToken(): string | null {
+    try {
+      const settings = database.getAllSettings();
+      return settings.githubToken || env.get('GITHUB_TOKEN') || null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+export const gitAskPassService = new GitAskPassService();

--- a/src/main/services/terminal.service.ts
+++ b/src/main/services/terminal.service.ts
@@ -12,6 +12,7 @@ import * as path from 'path';
 import { BrowserWindow } from 'electron';
 import { v4 as uuidv4 } from 'uuid';
 import type { ShellType, TerminalSession } from '../ipc/channels';
+import { gitAskPassService } from './git-askpass.service';
 
 interface PtySession {
   pty: pty.IPty;
@@ -93,6 +94,7 @@ class TerminalService {
       cwd: workingDirectory,
       env: {
         ...process.env,
+        ...gitAskPassService.getAskPassEnv(),
         TERM: 'xterm-256color',
       },
     });

--- a/tests/main/services/git-askpass.service.test.ts
+++ b/tests/main/services/git-askpass.service.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock electron
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/mock/userData'),
+  },
+}));
+
+// Mock fs
+const mockExistsSync = vi.fn();
+const mockMkdirSync = vi.fn();
+const mockWriteFileSync = vi.fn();
+const mockUnlinkSync = vi.fn();
+const mockRmSync = vi.fn();
+vi.mock('fs', () => ({
+  existsSync: (...args: unknown[]) => mockExistsSync(...args),
+  mkdirSync: (...args: unknown[]) => mockMkdirSync(...args),
+  writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
+  unlinkSync: (...args: unknown[]) => mockUnlinkSync(...args),
+  rmSync: (...args: unknown[]) => mockRmSync(...args),
+}));
+
+// Mock database
+const mockGetAllSettings = vi.fn();
+vi.mock('../../../src/main/database', () => ({
+  database: {
+    getAllSettings: () => mockGetAllSettings(),
+  },
+}));
+
+// Mock environment service
+const mockEnvGet = vi.fn();
+vi.mock('../../../src/main/services/environment.service', () => ({
+  env: {
+    get: (key: string) => mockEnvGet(key),
+  },
+}));
+
+// Import after mocks
+import { gitAskPassService } from '../../../src/main/services/git-askpass.service';
+
+describe('GitAskPassService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExistsSync.mockReturnValue(false);
+    mockGetAllSettings.mockReturnValue({});
+    mockEnvGet.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    // Reset service state by cleaning up
+    try {
+      gitAskPassService.cleanup();
+    } catch {
+      // Ignore cleanup errors in tests
+    }
+    vi.clearAllMocks();
+  });
+
+  describe('initialize', () => {
+    it('creates askpass directory if it does not exist', () => {
+      mockExistsSync.mockReturnValue(false);
+      mockGetAllSettings.mockReturnValue({ githubToken: 'test-token' });
+
+      gitAskPassService.initialize();
+
+      expect(mockMkdirSync).toHaveBeenCalledWith(expect.stringContaining('git-askpass'), {
+        recursive: true,
+      });
+    });
+
+    it('does not recreate directory if it already exists', () => {
+      // First call for dir check returns true, token file check returns false
+      mockExistsSync.mockReturnValue(true);
+      mockGetAllSettings.mockReturnValue({ githubToken: 'test-token' });
+
+      gitAskPassService.initialize();
+
+      expect(mockMkdirSync).not.toHaveBeenCalled();
+    });
+
+    it('writes platform-specific script on Windows', () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+
+      mockGetAllSettings.mockReturnValue({ githubToken: 'test-token' });
+
+      gitAskPassService.initialize();
+
+      // Should write script file
+      const scriptCall = mockWriteFileSync.mock.calls.find((call: unknown[]) =>
+        (call[0] as string).endsWith('.bat')
+      );
+      expect(scriptCall).toBeDefined();
+      expect(scriptCall![1]).toContain('@echo off');
+      expect(scriptCall![1]).toContain('findstr /i "username"');
+      expect(scriptCall![1]).toContain('x-access-token');
+
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    });
+
+    it('writes platform-specific script on Unix', () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+
+      mockGetAllSettings.mockReturnValue({ githubToken: 'test-token' });
+
+      gitAskPassService.initialize();
+
+      // Should write script file
+      const scriptCall = mockWriteFileSync.mock.calls.find((call: unknown[]) =>
+        (call[0] as string).endsWith('.sh')
+      );
+      expect(scriptCall).toBeDefined();
+      expect(scriptCall![1]).toContain('#!/bin/sh');
+      expect(scriptCall![1]).toContain('x-access-token');
+      expect(scriptCall![1]).toContain('*sername*)');
+
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    });
+
+    it('writes token file with restricted permissions when token exists', () => {
+      mockGetAllSettings.mockReturnValue({ githubToken: 'my-secret-token' });
+
+      gitAskPassService.initialize();
+
+      const tokenCall = mockWriteFileSync.mock.calls.find((call: unknown[]) =>
+        (call[0] as string).includes('git-token.txt')
+      );
+      expect(tokenCall).toBeDefined();
+      expect(tokenCall![1]).toBe('my-secret-token');
+      expect(tokenCall![2]).toEqual({ mode: 0o600 });
+    });
+
+    it('does not write token file when no token configured', () => {
+      mockGetAllSettings.mockReturnValue({});
+      mockEnvGet.mockReturnValue(undefined);
+
+      gitAskPassService.initialize();
+
+      const tokenCall = mockWriteFileSync.mock.calls.find((call: unknown[]) =>
+        (call[0] as string).includes('git-token.txt')
+      );
+      expect(tokenCall).toBeUndefined();
+    });
+
+    it('reads token from GITHUB_TOKEN env when DB has no token', () => {
+      mockGetAllSettings.mockReturnValue({});
+      mockEnvGet.mockImplementation((key: string) =>
+        key === 'GITHUB_TOKEN' ? 'env-token' : undefined
+      );
+
+      gitAskPassService.initialize();
+
+      const tokenCall = mockWriteFileSync.mock.calls.find((call: unknown[]) =>
+        (call[0] as string).includes('git-token.txt')
+      );
+      expect(tokenCall).toBeDefined();
+      expect(tokenCall![1]).toBe('env-token');
+    });
+
+    it('script content contains no secrets', () => {
+      mockGetAllSettings.mockReturnValue({ githubToken: 'super-secret-token' });
+
+      gitAskPassService.initialize();
+
+      // Find the script write call (not the token file)
+      const scriptCall = mockWriteFileSync.mock.calls.find(
+        (call: unknown[]) =>
+          (call[0] as string).endsWith('.sh') || (call[0] as string).endsWith('.bat')
+      );
+      expect(scriptCall).toBeDefined();
+      expect(scriptCall![1]).not.toContain('super-secret-token');
+    });
+  });
+
+  describe('getAskPassEnv', () => {
+    it('returns GIT_ASKPASS and GIT_TERMINAL_PROMPT when initialized with token', () => {
+      mockGetAllSettings.mockReturnValue({ githubToken: 'test-token' });
+      // Token file exists after initialization
+      mockExistsSync.mockReturnValue(false); // dir doesn't exist at first
+
+      gitAskPassService.initialize();
+
+      // After initialization, token file should exist
+      mockExistsSync.mockReturnValue(true);
+
+      const env = gitAskPassService.getAskPassEnv();
+
+      expect(env).toHaveProperty('GIT_ASKPASS');
+      expect(env).toHaveProperty('GIT_TERMINAL_PROMPT', '0');
+      expect(env.GIT_ASKPASS).toContain('git-askpass');
+    });
+
+    it('returns empty object when not initialized', () => {
+      // Don't call initialize
+      gitAskPassService.cleanup(); // Reset state
+      const env = gitAskPassService.getAskPassEnv();
+      expect(env).toEqual({});
+    });
+
+    it('returns empty object when token file does not exist', () => {
+      mockGetAllSettings.mockReturnValue({});
+
+      gitAskPassService.initialize();
+      // Token file doesn't exist (no token was set)
+      mockExistsSync.mockReturnValue(false);
+
+      const env = gitAskPassService.getAskPassEnv();
+      expect(env).toEqual({});
+    });
+  });
+
+  describe('updateToken', () => {
+    it('writes new token file when token provided', () => {
+      mockGetAllSettings.mockReturnValue({ githubToken: 'initial-token' });
+      gitAskPassService.initialize();
+      mockWriteFileSync.mockClear();
+
+      gitAskPassService.updateToken('new-token');
+
+      const tokenCall = mockWriteFileSync.mock.calls.find((call: unknown[]) =>
+        (call[0] as string).includes('git-token.txt')
+      );
+      expect(tokenCall).toBeDefined();
+      expect(tokenCall![1]).toBe('new-token');
+      expect(tokenCall![2]).toEqual({ mode: 0o600 });
+    });
+
+    it('removes token file when null passed', () => {
+      mockGetAllSettings.mockReturnValue({ githubToken: 'initial-token' });
+      gitAskPassService.initialize();
+
+      // Token file exists
+      mockExistsSync.mockReturnValue(true);
+
+      gitAskPassService.updateToken(null);
+
+      expect(mockUnlinkSync).toHaveBeenCalledWith(expect.stringContaining('git-token.txt'));
+    });
+
+    it('does nothing when null passed and token file does not exist', () => {
+      mockGetAllSettings.mockReturnValue({ githubToken: 'initial-token' });
+      gitAskPassService.initialize();
+
+      mockExistsSync.mockReturnValue(false);
+
+      gitAskPassService.updateToken(null);
+
+      expect(mockUnlinkSync).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when not initialized', () => {
+      gitAskPassService.cleanup();
+      mockWriteFileSync.mockClear();
+
+      gitAskPassService.updateToken('token');
+
+      // No token file write (only script writes during init, not after cleanup)
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanup', () => {
+    it('removes askpass directory recursively', () => {
+      mockGetAllSettings.mockReturnValue({ githubToken: 'test-token' });
+      gitAskPassService.initialize();
+
+      mockExistsSync.mockReturnValue(true);
+
+      gitAskPassService.cleanup();
+
+      expect(mockRmSync).toHaveBeenCalledWith(expect.stringContaining('git-askpass'), {
+        recursive: true,
+        force: true,
+      });
+    });
+
+    it('does not throw when directory does not exist', () => {
+      mockGetAllSettings.mockReturnValue({ githubToken: 'test-token' });
+      gitAskPassService.initialize();
+
+      mockExistsSync.mockReturnValue(false);
+
+      expect(() => gitAskPassService.cleanup()).not.toThrow();
+    });
+
+    it('handles fs errors gracefully', () => {
+      mockGetAllSettings.mockReturnValue({ githubToken: 'test-token' });
+      gitAskPassService.initialize();
+
+      mockExistsSync.mockReturnValue(true);
+      mockRmSync.mockImplementationOnce(() => {
+        throw new Error('Permission denied');
+      });
+
+      expect(() => gitAskPassService.cleanup()).not.toThrow();
+    });
+
+    it('resets initialized state so getAskPassEnv returns empty', () => {
+      mockGetAllSettings.mockReturnValue({ githubToken: 'test-token' });
+      gitAskPassService.initialize();
+
+      gitAskPassService.cleanup();
+
+      const env = gitAskPassService.getAskPassEnv();
+      expect(env).toEqual({});
+    });
+  });
+});

--- a/tests/main/services/terminal.service.test.ts
+++ b/tests/main/services/terminal.service.test.ts
@@ -20,6 +20,14 @@ vi.mock('os', () => ({
   homedir: () => '/mock/home',
 }));
 
+// Mock git-askpass service
+const mockGetAskPassEnv = vi.fn();
+vi.mock('../../../src/main/services/git-askpass.service', () => ({
+  gitAskPassService: {
+    getAskPassEnv: () => mockGetAskPassEnv(),
+  },
+}));
+
 // Mock node-pty
 const mockWrite = vi.fn();
 const mockResize = vi.fn();
@@ -52,6 +60,12 @@ describe('TerminalService', () => {
 
     // Setup default window mock
     mockGetAllWindows.mockReturnValue([{ webContents: { send: mockSend } }]);
+
+    // Default askpass env
+    mockGetAskPassEnv.mockReturnValue({
+      GIT_ASKPASS: '/mock/path/git-askpass.sh',
+      GIT_TERMINAL_PROMPT: '0',
+    });
   });
 
   afterEach(() => {
@@ -160,6 +174,62 @@ describe('TerminalService', () => {
         [],
         expect.objectContaining({ cwd: '/test/dir' })
       );
+
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    });
+
+    it('includes GIT_ASKPASS env vars in PTY spawn', () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+
+      terminalService.cleanup();
+      vi.mocked(pty.spawn).mockClear();
+
+      terminalService.spawn('git-bash', '/test/dir');
+
+      const spawnCall = vi.mocked(pty.spawn).mock.calls[0];
+      const env = spawnCall[2]?.env as Record<string, string>;
+      expect(env.GIT_ASKPASS).toBe('/mock/path/git-askpass.sh');
+      expect(env.GIT_TERMINAL_PROMPT).toBe('0');
+
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    });
+
+    it('preserves existing env vars alongside askpass env', () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+
+      terminalService.cleanup();
+      vi.mocked(pty.spawn).mockClear();
+
+      terminalService.spawn('git-bash', '/test/dir');
+
+      const spawnCall = vi.mocked(pty.spawn).mock.calls[0];
+      const env = spawnCall[2]?.env as Record<string, string>;
+      // TERM should still be set
+      expect(env.TERM).toBe('xterm-256color');
+      // process.env vars should be present too
+      expect(env.PATH).toBeDefined();
+
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    });
+
+    it('works without askpass env when no token configured', () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+
+      mockGetAskPassEnv.mockReturnValue({});
+
+      terminalService.cleanup();
+      vi.mocked(pty.spawn).mockClear();
+
+      terminalService.spawn('git-bash', '/test/dir');
+
+      const spawnCall = vi.mocked(pty.spawn).mock.calls[0];
+      const env = spawnCall[2]?.env as Record<string, string>;
+      expect(env.GIT_ASKPASS).toBeUndefined();
+      expect(env.GIT_TERMINAL_PROMPT).toBeUndefined();
+      expect(env.TERM).toBe('xterm-256color');
 
       Object.defineProperty(process, 'platform', { value: originalPlatform });
     });


### PR DESCRIPTION
## Summary
- Add GIT_ASKPASS credential helper so Git operations in the Tool Box Terminal authenticate automatically using the app's stored GitHub token ([#37](https://github.com/lukadfagundes/cola-records/issues/37))
- Platform-specific askpass script (`.sh`/`.bat`) reads token from a secure file (0o600 permissions) — no secrets in the script itself
- Token file updates immediately when changed in Settings; all files cleaned up on app quit