### PR TITLE
Fix/45 Push Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed `credential.helper` override from GIT_ASKPASS env injection — blanking the system credential helper caused "Invalid username or token" errors when the app token differed from the system credential ([#37](https://github.com/lukadfagundes/cola-records/issues/37))
+
 ## [1.0.8] - 2026-02-23
 
 ### Added

--- a/src/main/services/git-askpass.service.ts
+++ b/src/main/services/git-askpass.service.ts
@@ -60,10 +60,15 @@ class GitAskPassService {
       const token = this.getCurrentToken();
       if (token) {
         this.writeTokenFile(token);
+        logger.info(`Token written (length=${token.length}, prefix=${token.substring(0, 10)}...)`);
+      } else {
+        logger.info('No token found — askpass script will have no token to provide');
       }
 
       this.initialized = true;
       logger.info('Initialized askpass helper', this.askpassDir);
+      logger.info(`Script path: ${this.scriptPath}`);
+      logger.info(`Token path: ${this.tokenPath}`);
     } catch (error) {
       logger.warn('Failed to initialize askpass helper', error);
     }
@@ -75,17 +80,16 @@ class GitAskPassService {
    */
   getAskPassEnv(): Record<string, string> {
     if (!this.initialized || !fs.existsSync(this.tokenPath)) {
+      logger.debug(
+        `getAskPassEnv returning empty (initialized=${this.initialized}, tokenExists=${this.initialized && fs.existsSync(this.tokenPath)})`
+      );
       return {};
     }
 
+    logger.debug(`getAskPassEnv returning GIT_ASKPASS=${this.scriptPath}`);
     return {
       GIT_ASKPASS: this.scriptPath,
       GIT_TERMINAL_PROMPT: '0',
-      // Override any system/global credential.helper (e.g. Git Credential Manager)
-      // so Git falls through to GIT_ASKPASS instead of opening a browser OAuth flow.
-      GIT_CONFIG_COUNT: '1',
-      GIT_CONFIG_KEY_0: 'credential.helper',
-      GIT_CONFIG_VALUE_0: '',
     };
   }
 
@@ -148,18 +152,23 @@ class GitAskPassService {
   private getWindowsScript(tokenFilePath: string): string {
     // Normalize to Windows backslashes for the batch file
     const winTokenPath = tokenFilePath.replace(/\//g, '\\');
+    const logPath = path.join(this.askpassDir, 'askpass-debug.log').replace(/\//g, '\\');
     return [
       '@echo off',
-      'setlocal',
-      'echo %1 | findstr /i "username" >nul',
+      'setlocal enabledelayedexpansion',
+      `echo [%date% %time%] askpass called with: "%~1" >> "${logPath}"`,
+      'echo %~1 | findstr /i "username" >nul',
       'if %errorlevel% equ 0 (',
+      `  echo [%date% %time%] responding with: x-access-token >> "${logPath}"`,
       '  echo x-access-token',
       '  exit /b 0',
       ')',
       `if exist "${winTokenPath}" (`,
       `  set /p TOKEN=<"${winTokenPath}"`,
-      '  echo %TOKEN%',
+      `  echo [%date% %time%] responding with token (first4=!TOKEN:~0,4!...) >> "${logPath}" 2>nul`,
+      '  echo !TOKEN!',
       ') else (',
+      `  echo [%date% %time%] token file not found >> "${logPath}"`,
       '  echo.',
       ')',
       '',

--- a/tests/main/services/git-askpass.service.test.ts
+++ b/tests/main/services/git-askpass.service.test.ts
@@ -191,10 +191,11 @@ describe('GitAskPassService', () => {
       expect(env).toHaveProperty('GIT_ASKPASS');
       expect(env).toHaveProperty('GIT_TERMINAL_PROMPT', '0');
       expect(env.GIT_ASKPASS).toContain('git-askpass');
-      // Should override credential.helper to prevent GCM from intercepting
-      expect(env).toHaveProperty('GIT_CONFIG_COUNT', '1');
-      expect(env).toHaveProperty('GIT_CONFIG_KEY_0', 'credential.helper');
-      expect(env).toHaveProperty('GIT_CONFIG_VALUE_0', '');
+      // Should NOT override credential.helper — GIT_ASKPASS already takes priority
+      // and blanking credential.helper breaks the user's system credential fallback
+      expect(env).not.toHaveProperty('GIT_CONFIG_COUNT');
+      expect(env).not.toHaveProperty('GIT_CONFIG_KEY_0');
+      expect(env).not.toHaveProperty('GIT_CONFIG_VALUE_0');
     });
 
     it('returns empty object when not initialized', () => {

--- a/tests/main/services/terminal.service.test.ts
+++ b/tests/main/services/terminal.service.test.ts
@@ -220,6 +220,13 @@ describe('TerminalService', () => {
 
       mockGetAskPassEnv.mockReturnValue({});
 
+      // Save and clear any GIT_ASKPASS that may exist in process.env
+      // (e.g. set by the real singleton during other test files in the same run)
+      const savedAskPass = process.env.GIT_ASKPASS;
+      const savedTermPrompt = process.env.GIT_TERMINAL_PROMPT;
+      delete process.env.GIT_ASKPASS;
+      delete process.env.GIT_TERMINAL_PROMPT;
+
       terminalService.cleanup();
       vi.mocked(pty.spawn).mockClear();
 
@@ -231,6 +238,9 @@ describe('TerminalService', () => {
       expect(env.GIT_TERMINAL_PROMPT).toBeUndefined();
       expect(env.TERM).toBe('xterm-256color');
 
+      // Restore
+      if (savedAskPass !== undefined) process.env.GIT_ASKPASS = savedAskPass;
+      if (savedTermPrompt !== undefined) process.env.GIT_TERMINAL_PROMPT = savedTermPrompt;
       Object.defineProperty(process, 'platform', { value: originalPlatform });
     });
 


### PR DESCRIPTION
## Summary
- Fixed GIT_ASKPASS Windows batch script sending empty password to Git — `%TOKEN%` was expanded at parse time (before `set /p` read the file), causing authentication failure
- Removed aggressive `credential.helper` override that blanked the system credential manager, breaking fallback auth
- Fixed pre-existing test isolation issue where `process.env.GIT_ASKPASS` leaked between test files

## Root Cause
Windows batch files expand `%VAR%` inside parenthesized `if` blocks at parse time, not execution time. `set /p TOKEN=<file` and `echo %TOKEN%` in the same block meant the token was always empty. Fix: `setlocal enabledelayedexpansion` + `!TOKEN!`.