### PR TITLE
Feat/71 Global Dev Scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **7 IPC channels**: `github-config:scan`, `github-config:read-file`, `github-config:write-file`, `github-config:delete-file`, `github-config:create-from-template`, `github-config:list-templates`, `github-config:list-issue-templates`
   - **3 integrations**: PR Template auto-populates CreatePullRequestModal body, Issue Templates add template selector dropdown to CreateIssueModal, ActionsTool "Edit" button cross-links to GitHub Config workflows editor
   - **12+ templates**: CI Node.js, Release, Auto-Close Issues, Dependabot npm, Release Notes categories, Bug Report, Feature Request, Issue Config, PR checklist, Labeler rules, CODEOWNERS solo, Auto-Assign self, Copilot conventions, Funding placeholder, Security policy, Stale management
+- **Global Dev Scripts** — new Settings tab for creating dev scripts accessible by all projects (#71)
+  - `GLOBAL_SCRIPTS_PATH` sentinel (`__global__`) reuses existing `dev_scripts` table and IPC channels with zero schema migration
+  - **GlobalScriptsTab** (`GlobalScriptsTab.tsx`): full CRUD settings tab with same 3-mode form (Single, Multi-Terminal, Toggle) as DevScriptsTool
+  - Zustand store extended with `globalScripts` state, `loadGlobalScripts()`, `saveGlobalScript()`, `deleteGlobalScript()` actions — `loadScripts()` now fetches both project + global scripts in parallel via `Promise.all`
+  - **DevScriptsTool** shows global scripts in a separate "Global Scripts" section with dashed-border cards, Globe badge, run-only buttons (no edit/delete), and "Manage global scripts in Settings" hint
+  - **DevelopmentScreen** header bar renders global script buttons alongside project-specific scripts for one-click execution from any project
 - Dev Tools — Set Up category with 6 ecosystem-aware action buttons: Install, Env File, Git Init, Hooks, Editor Config, TypeCheck
   - **Project Detection Service** (`project-detection.service.ts`): scans working directory to detect ecosystem (Node, Python, Rust, Go, Ruby, PHP, Java), package manager, available scripts, and tooling
   - 7 new IPC channels (`dev-tools:detect-project`, `dev-tools:get-install-command`, `dev-tools:get-typecheck-command`, `dev-tools:get-git-init-command`, `dev-tools:get-hooks-command`, `dev-tools:setup-env-file`, `dev-tools:setup-editor-config`)
@@ -199,6 +205,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tests
 
+- Global Dev Scripts tests: GlobalScriptsTab (14 tests — rendering, form validation, save, delete confirmation), useDevScriptsStore global actions (8 tests — loadGlobalScripts, saveGlobalScript, deleteGlobalScript, project isolation), DevScriptsTool global display (8 tests — section rendering, badge, run execution, no edit/delete, alongside project scripts)
 - GitHub Config service tests (`github-config.service.test.ts`): 56 tests covering scan, readFile, writeFile, deleteFile, createFromTemplate (overwrite protection, subdirectory targeting), listTemplates (all 12 features), listIssueTemplates (YAML front-matter parsing, label formats, quote stripping)
 - GitHub Config component tests: GitHubConfigTool (10 tests), GitHubConfigPanel (15 tests), MarkdownEditor (5), YamlEditor (5), WorkflowsEditor (7), IssueTemplatesEditor (7), CodeownersEditor (5)
 - ChipInput component tests (`ChipInput.test.tsx`): 8 tests covering chip rendering, add via Enter/comma, remove via X/Backspace, duplicate prevention, empty prevention, placeholder

--- a/src/main/ipc/channels/types.ts
+++ b/src/main/ipc/channels/types.ts
@@ -431,6 +431,9 @@ export interface DevScriptToggle {
   secondPressCommand: string;
 }
 
+/** Sentinel project_path for global dev scripts (accessible by all projects) */
+export const GLOBAL_SCRIPTS_PATH = '__global__';
+
 export interface DevScript {
   id: string;
   projectPath: string;

--- a/src/renderer/components/settings/GlobalScriptsTab.tsx
+++ b/src/renderer/components/settings/GlobalScriptsTab.tsx
@@ -1,0 +1,806 @@
+/**
+ * GlobalScriptsTab
+ *
+ * Settings tab for managing Global Dev Scripts that are accessible by all projects.
+ * Reuses the same form patterns as DevScriptsTool (Single, Multi-Terminal, Toggle modes).
+ * Scripts are stored with projectPath = '__global__' sentinel value.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Plus,
+  Pencil,
+  Trash2,
+  X,
+  GripVertical,
+  ChevronDown,
+  ChevronRight,
+  Terminal,
+  Layers,
+  Power,
+  Globe,
+} from 'lucide-react';
+import { Button } from '../ui/Button';
+import { useDevScriptsStore } from '../../stores/useDevScriptsStore';
+import { GLOBAL_SCRIPTS_PATH } from '../../../main/ipc/channels/types';
+import type { DevScript, DevScriptTerminal } from '../../../main/ipc/channels';
+import { cn } from '../../lib/utils';
+
+type ScriptMode = 'single' | 'multi' | 'toggle';
+
+export function GlobalScriptsTab() {
+  const { globalScripts, loading, loadGlobalScripts, saveGlobalScript, deleteGlobalScript } =
+    useDevScriptsStore();
+
+  // Form state
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingScript, setEditingScript] = useState<DevScript | null>(null);
+  const [name, setName] = useState('');
+  const [commands, setCommands] = useState<string[]>(['']);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [scriptMode, setScriptMode] = useState<ScriptMode>('single');
+
+  // Multi-terminal state
+  const [terminals, setTerminals] = useState<DevScriptTerminal[]>([]);
+  const [expandedTerminals, setExpandedTerminals] = useState<Set<number>>(new Set([0]));
+
+  // Toggle state
+  const [firstPressName, setFirstPressName] = useState('');
+  const [firstPressCommand, setFirstPressCommand] = useState('');
+  const [secondPressName, setSecondPressName] = useState('');
+  const [secondPressCommand, setSecondPressCommand] = useState('');
+
+  // Delete confirmation
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadGlobalScripts();
+  }, [loadGlobalScripts]);
+
+  const resetForm = useCallback(() => {
+    setName('');
+    setCommands(['']);
+    setTerminals([]);
+    setScriptMode('single');
+    setExpandedTerminals(new Set([0]));
+    setFirstPressName('');
+    setFirstPressCommand('');
+    setSecondPressName('');
+    setSecondPressCommand('');
+    setEditingScript(null);
+    setFormError(null);
+    setIsFormOpen(false);
+  }, []);
+
+  const handleOpenAddForm = useCallback(() => {
+    resetForm();
+    setIsFormOpen(true);
+  }, [resetForm]);
+
+  const handleOpenEditForm = useCallback((script: DevScript) => {
+    setEditingScript(script);
+    setName(script.name);
+
+    if (script.toggle) {
+      setScriptMode('toggle');
+      setFirstPressName(script.toggle.firstPressName);
+      setFirstPressCommand(script.toggle.firstPressCommand);
+      setSecondPressName(script.toggle.secondPressName);
+      setSecondPressCommand(script.toggle.secondPressCommand);
+      setCommands(['']);
+      setTerminals([]);
+    } else if (script.terminals && script.terminals.length > 0) {
+      setScriptMode('multi');
+      setTerminals(script.terminals.map((t) => ({ ...t, commands: [...t.commands] })));
+      setCommands(['']);
+      setExpandedTerminals(new Set([0]));
+      setFirstPressName('');
+      setFirstPressCommand('');
+      setSecondPressName('');
+      setSecondPressCommand('');
+    } else {
+      setScriptMode('single');
+      setTerminals([]);
+      setCommands(script.commands.length > 0 ? script.commands : [script.command]);
+      setFirstPressName('');
+      setFirstPressCommand('');
+      setSecondPressName('');
+      setSecondPressCommand('');
+    }
+
+    setFormError(null);
+    setIsFormOpen(true);
+  }, []);
+
+  const handleSubmit = useCallback(async () => {
+    if (scriptMode === 'toggle') {
+      if (!firstPressName.trim()) {
+        setFormError('First press name is required');
+        return;
+      }
+      if (!firstPressCommand.trim()) {
+        setFormError('First press command is required');
+        return;
+      }
+      if (!secondPressName.trim()) {
+        setFormError('Second press name is required');
+        return;
+      }
+      if (!secondPressCommand.trim()) {
+        setFormError('Second press command is required');
+        return;
+      }
+
+      const toggleName = firstPressName.trim();
+      const duplicate = globalScripts.find(
+        (s) => s.name.toLowerCase() === toggleName.toLowerCase() && s.id !== editingScript?.id
+      );
+      if (duplicate) {
+        setFormError('A global script with this name already exists');
+        return;
+      }
+
+      try {
+        await saveGlobalScript({
+          id:
+            editingScript?.id || `script_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+          projectPath: GLOBAL_SCRIPTS_PATH,
+          name: toggleName,
+          command: firstPressCommand.trim(),
+          commands: [firstPressCommand.trim()],
+          terminals: undefined,
+          toggle: {
+            firstPressName: firstPressName.trim(),
+            firstPressCommand: firstPressCommand.trim(),
+            secondPressName: secondPressName.trim(),
+            secondPressCommand: secondPressCommand.trim(),
+          },
+        });
+        resetForm();
+      } catch (error) {
+        setFormError(String(error));
+      }
+      return;
+    }
+
+    if (!name.trim()) {
+      setFormError('Name is required');
+      return;
+    }
+
+    const duplicate = globalScripts.find(
+      (s) => s.name.toLowerCase() === name.trim().toLowerCase() && s.id !== editingScript?.id
+    );
+    if (duplicate) {
+      setFormError('A global script with this name already exists');
+      return;
+    }
+
+    if (scriptMode === 'multi') {
+      if (terminals.length === 0) {
+        setFormError('At least one terminal is required');
+        return;
+      }
+      for (let i = 0; i < terminals.length; i++) {
+        const terminal = terminals[i];
+        if (!terminal.name.trim()) {
+          setFormError(`Terminal ${i + 1} needs a name`);
+          return;
+        }
+        const validCmds = terminal.commands.filter((c) => c.trim().length > 0);
+        if (validCmds.length === 0) {
+          setFormError(`Terminal "${terminal.name}" needs at least one command`);
+          return;
+        }
+      }
+      const terminalNames = terminals.map((t) => t.name.trim().toLowerCase());
+      if (new Set(terminalNames).size !== terminalNames.length) {
+        setFormError('Terminal names must be unique');
+        return;
+      }
+
+      const cleanTerminals = terminals.map((t) => ({
+        name: t.name.trim(),
+        commands: t.commands.map((c) => c.trim()).filter((c) => c.length > 0),
+      }));
+
+      try {
+        await saveGlobalScript({
+          id:
+            editingScript?.id || `script_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+          projectPath: GLOBAL_SCRIPTS_PATH,
+          name: name.trim(),
+          command: cleanTerminals[0].commands[0],
+          commands: cleanTerminals[0].commands,
+          terminals: cleanTerminals,
+        });
+        resetForm();
+      } catch (error) {
+        setFormError(String(error));
+      }
+    } else {
+      const validCommands = commands.map((c) => c.trim()).filter((c) => c.length > 0);
+      if (validCommands.length === 0) {
+        setFormError('At least one command is required');
+        return;
+      }
+
+      try {
+        await saveGlobalScript({
+          id:
+            editingScript?.id || `script_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+          projectPath: GLOBAL_SCRIPTS_PATH,
+          name: name.trim(),
+          command: validCommands[0],
+          commands: validCommands,
+          terminals: undefined,
+        });
+        resetForm();
+      } catch (error) {
+        setFormError(String(error));
+      }
+    }
+  }, [
+    name,
+    commands,
+    terminals,
+    scriptMode,
+    firstPressName,
+    firstPressCommand,
+    secondPressName,
+    secondPressCommand,
+    globalScripts,
+    editingScript,
+    saveGlobalScript,
+    resetForm,
+  ]);
+
+  const handleAddCommand = useCallback(() => {
+    setCommands((prev) => [...prev, '']);
+  }, []);
+
+  const handleRemoveCommand = useCallback((index: number) => {
+    setCommands((prev) => (prev.length <= 1 ? prev : prev.filter((_, i) => i !== index)));
+  }, []);
+
+  const handleCommandChange = useCallback((index: number, value: string) => {
+    setCommands((prev) => {
+      const next = [...prev];
+      next[index] = value;
+      return next;
+    });
+  }, []);
+
+  const handleAddTerminal = useCallback(() => {
+    setTerminals((prev) => [...prev, { name: '', commands: [''] }]);
+    setExpandedTerminals((prev) => new Set([...prev, terminals.length]));
+  }, [terminals.length]);
+
+  const handleRemoveTerminal = useCallback((index: number) => {
+    setTerminals((prev) => (prev.length <= 1 ? prev : prev.filter((_, i) => i !== index)));
+    setExpandedTerminals((prev) => {
+      const next = new Set<number>();
+      prev.forEach((i) => {
+        if (i < index) next.add(i);
+        else if (i > index) next.add(i - 1);
+      });
+      return next;
+    });
+  }, []);
+
+  const handleTerminalNameChange = useCallback((index: number, value: string) => {
+    setTerminals((prev) => {
+      const next = [...prev];
+      next[index] = { ...next[index], name: value };
+      return next;
+    });
+  }, []);
+
+  const handleTerminalCommandChange = useCallback(
+    (terminalIndex: number, commandIndex: number, value: string) => {
+      setTerminals((prev) => {
+        const next = [...prev];
+        const cmds = [...next[terminalIndex].commands];
+        cmds[commandIndex] = value;
+        next[terminalIndex] = { ...next[terminalIndex], commands: cmds };
+        return next;
+      });
+    },
+    []
+  );
+
+  const handleAddTerminalCommand = useCallback((terminalIndex: number) => {
+    setTerminals((prev) => {
+      const next = [...prev];
+      next[terminalIndex] = {
+        ...next[terminalIndex],
+        commands: [...next[terminalIndex].commands, ''],
+      };
+      return next;
+    });
+  }, []);
+
+  const handleRemoveTerminalCommand = useCallback((terminalIndex: number, commandIndex: number) => {
+    setTerminals((prev) => {
+      const next = [...prev];
+      const terminal = next[terminalIndex];
+      if (terminal.commands.length <= 1) return prev;
+      next[terminalIndex] = {
+        ...terminal,
+        commands: terminal.commands.filter((_, i) => i !== commandIndex),
+      };
+      return next;
+    });
+  }, []);
+
+  const toggleTerminalExpanded = useCallback((index: number) => {
+    setExpandedTerminals((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
+      return next;
+    });
+  }, []);
+
+  const handleModeChange = useCallback(
+    (mode: ScriptMode) => {
+      setScriptMode(mode);
+      if (mode === 'multi' && terminals.length === 0) {
+        const validCommands = commands.filter((c) => c.trim().length > 0);
+        setTerminals([
+          { name: 'Terminal 1', commands: validCommands.length > 0 ? validCommands : [''] },
+        ]);
+        setExpandedTerminals(new Set([0]));
+      }
+    },
+    [commands, terminals.length]
+  );
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      try {
+        await deleteGlobalScript(id);
+        setDeleteConfirmId(null);
+      } catch {
+        // Error is set in store
+      }
+    },
+    [deleteGlobalScript]
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-lg font-medium">Global Dev Scripts</h3>
+        <p className="text-sm text-muted-foreground mt-1">
+          Scripts defined here are available in every project. They appear alongside
+          project-specific scripts in the Development screen.
+        </p>
+      </div>
+
+      {/* Add button */}
+      <div className="flex justify-end">
+        <Button size="sm" onClick={handleOpenAddForm} disabled={isFormOpen}>
+          <Plus className="h-4 w-4 mr-1" />
+          Add Global Script
+        </Button>
+      </div>
+
+      {/* Add/Edit Form */}
+      {isFormOpen && (
+        <div className="p-4 bg-muted/30 rounded-lg border border-border">
+          <h4 className="text-sm font-medium mb-3">
+            {editingScript ? 'Edit Global Script' : 'New Global Script'}
+          </h4>
+
+          <div className="space-y-3">
+            {/* Script Name (hidden in toggle mode) */}
+            {scriptMode !== 'toggle' && (
+              <div>
+                <label className="text-xs text-muted-foreground block mb-1">Name</label>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="e.g., Build, Test, Dev"
+                  className="w-full px-3 py-2 text-sm bg-background border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-ring"
+                  data-testid="global-script-name"
+                />
+              </div>
+            )}
+
+            {/* Mode Selector */}
+            <div>
+              <label className="text-xs text-muted-foreground block mb-2">Mode</label>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => handleModeChange('single')}
+                  className={cn(
+                    'flex items-center gap-2 px-3 py-2 text-sm rounded-md border transition-colors',
+                    scriptMode === 'single'
+                      ? 'bg-primary text-primary-foreground border-primary'
+                      : 'bg-background border-input hover:border-primary/50'
+                  )}
+                >
+                  <Terminal className="h-4 w-4" />
+                  Single
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleModeChange('multi')}
+                  className={cn(
+                    'flex items-center gap-2 px-3 py-2 text-sm rounded-md border transition-colors',
+                    scriptMode === 'multi'
+                      ? 'bg-primary text-primary-foreground border-primary'
+                      : 'bg-background border-input hover:border-primary/50'
+                  )}
+                >
+                  <Layers className="h-4 w-4" />
+                  Multi
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleModeChange('toggle')}
+                  className={cn(
+                    'flex items-center gap-2 px-3 py-2 text-sm rounded-md border transition-colors',
+                    scriptMode === 'toggle'
+                      ? 'bg-primary text-primary-foreground border-primary'
+                      : 'bg-background border-input hover:border-primary/50'
+                  )}
+                >
+                  <Power className="h-4 w-4" />
+                  Toggle
+                </button>
+              </div>
+              <p className="text-xs text-muted-foreground mt-1">
+                {scriptMode === 'multi'
+                  ? 'Launch multiple terminals in parallel (e.g., frontend + backend)'
+                  : scriptMode === 'toggle'
+                    ? 'Alternate between two commands (e.g., start / stop)'
+                    : 'Run commands sequentially in a single terminal'}
+              </p>
+            </div>
+
+            {/* Single Terminal Mode */}
+            {scriptMode === 'single' && (
+              <div>
+                <div className="flex items-center justify-between mb-1">
+                  <label className="text-xs text-muted-foreground">
+                    Commands {commands.length > 1 && `(${commands.length})`}
+                  </label>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleAddCommand}
+                    className="h-6 px-2 text-xs"
+                  >
+                    <Plus className="h-3 w-3 mr-1" />
+                    Add Command
+                  </Button>
+                </div>
+                <div className="space-y-2">
+                  {commands.map((cmd, index) => (
+                    <div key={index} className="flex items-center gap-2">
+                      <div className="flex items-center text-muted-foreground text-xs w-5">
+                        <GripVertical className="h-3 w-3" />
+                      </div>
+                      <input
+                        type="text"
+                        value={cmd}
+                        onChange={(e) => handleCommandChange(index, e.target.value)}
+                        placeholder={index === 0 ? 'e.g., npm install' : 'e.g., npm run build'}
+                        className="flex-1 px-3 py-2 text-sm bg-background border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-ring font-mono"
+                        data-testid={`global-script-command-${index}`}
+                      />
+                      {commands.length > 1 && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleRemoveCommand(index)}
+                          className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Multi-Terminal Mode */}
+            {scriptMode === 'multi' && (
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <label className="text-xs text-muted-foreground">
+                    Terminals {terminals.length > 0 && `(${terminals.length})`}
+                  </label>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleAddTerminal}
+                    className="h-6 px-2 text-xs"
+                  >
+                    <Plus className="h-3 w-3 mr-1" />
+                    Add Terminal
+                  </Button>
+                </div>
+                <div className="space-y-2">
+                  {terminals.map((terminal, terminalIndex) => (
+                    <div
+                      key={terminalIndex}
+                      className="border border-input rounded-md bg-background overflow-hidden"
+                    >
+                      <div className="flex items-center gap-2 px-3 py-2 bg-muted/50">
+                        <button
+                          type="button"
+                          onClick={() => toggleTerminalExpanded(terminalIndex)}
+                          className="text-muted-foreground hover:text-foreground"
+                        >
+                          {expandedTerminals.has(terminalIndex) ? (
+                            <ChevronDown className="h-4 w-4" />
+                          ) : (
+                            <ChevronRight className="h-4 w-4" />
+                          )}
+                        </button>
+                        <Terminal className="h-4 w-4 text-muted-foreground" />
+                        <input
+                          type="text"
+                          value={terminal.name}
+                          onChange={(e) => handleTerminalNameChange(terminalIndex, e.target.value)}
+                          placeholder="Terminal name (e.g., Frontend)"
+                          className="flex-1 px-2 py-1 text-sm bg-transparent border-none focus:outline-none"
+                        />
+                        <span className="text-xs text-muted-foreground">
+                          {terminal.commands.filter((c) => c.trim()).length} cmd
+                        </span>
+                        {terminals.length > 1 && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => handleRemoveTerminal(terminalIndex)}
+                            className="h-6 w-6 text-muted-foreground hover:text-destructive"
+                          >
+                            <X className="h-3 w-3" />
+                          </Button>
+                        )}
+                      </div>
+                      {expandedTerminals.has(terminalIndex) && (
+                        <div className="p-3 border-t border-input space-y-2">
+                          {terminal.commands.map((cmd, cmdIndex) => (
+                            <div key={cmdIndex} className="flex items-center gap-2">
+                              <div className="flex items-center text-muted-foreground text-xs w-5">
+                                <GripVertical className="h-3 w-3" />
+                              </div>
+                              <input
+                                type="text"
+                                value={cmd}
+                                onChange={(e) =>
+                                  handleTerminalCommandChange(
+                                    terminalIndex,
+                                    cmdIndex,
+                                    e.target.value
+                                  )
+                                }
+                                placeholder={
+                                  cmdIndex === 0 ? 'e.g., npm run dev' : 'e.g., npm run watch'
+                                }
+                                className="flex-1 px-3 py-2 text-sm bg-muted/30 border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-ring font-mono"
+                              />
+                              {terminal.commands.length > 1 && (
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="icon"
+                                  onClick={() =>
+                                    handleRemoveTerminalCommand(terminalIndex, cmdIndex)
+                                  }
+                                  className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                                >
+                                  <X className="h-4 w-4" />
+                                </Button>
+                              )}
+                            </div>
+                          ))}
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handleAddTerminalCommand(terminalIndex)}
+                            className="h-6 px-2 text-xs w-full justify-center"
+                          >
+                            <Plus className="h-3 w-3 mr-1" />
+                            Add Command
+                          </Button>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Toggle Mode */}
+            {scriptMode === 'toggle' && (
+              <div className="space-y-3">
+                <div>
+                  <label className="text-xs text-muted-foreground block mb-1">
+                    First Press — Name
+                  </label>
+                  <input
+                    type="text"
+                    value={firstPressName}
+                    onChange={(e) => setFirstPressName(e.target.value)}
+                    placeholder="e.g., Start DB"
+                    className="w-full px-3 py-2 text-sm bg-background border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-ring"
+                    data-testid="global-script-toggle-first-name"
+                  />
+                </div>
+                <div>
+                  <label className="text-xs text-muted-foreground block mb-1">
+                    First Press — Command
+                  </label>
+                  <input
+                    type="text"
+                    value={firstPressCommand}
+                    onChange={(e) => setFirstPressCommand(e.target.value)}
+                    placeholder="e.g., docker compose up -d"
+                    className="w-full px-3 py-2 text-sm bg-background border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-ring font-mono"
+                    data-testid="global-script-toggle-first-cmd"
+                  />
+                </div>
+                <div>
+                  <label className="text-xs text-muted-foreground block mb-1">
+                    Second Press — Name
+                  </label>
+                  <input
+                    type="text"
+                    value={secondPressName}
+                    onChange={(e) => setSecondPressName(e.target.value)}
+                    placeholder="e.g., Stop DB"
+                    className="w-full px-3 py-2 text-sm bg-background border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-ring"
+                    data-testid="global-script-toggle-second-name"
+                  />
+                </div>
+                <div>
+                  <label className="text-xs text-muted-foreground block mb-1">
+                    Second Press — Command
+                  </label>
+                  <input
+                    type="text"
+                    value={secondPressCommand}
+                    onChange={(e) => setSecondPressCommand(e.target.value)}
+                    placeholder="e.g., docker compose down"
+                    className="w-full px-3 py-2 text-sm bg-background border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-ring font-mono"
+                    data-testid="global-script-toggle-second-cmd"
+                  />
+                </div>
+              </div>
+            )}
+
+            {formError && <p className="text-xs text-destructive">{formError}</p>}
+
+            <div className="flex gap-2">
+              <Button size="sm" onClick={handleSubmit} disabled={loading}>
+                {editingScript ? 'Save Changes' : 'Add Script'}
+              </Button>
+              <Button variant="ghost" size="sm" onClick={resetForm}>
+                Cancel
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Scripts List */}
+      {globalScripts.length === 0 && !isFormOpen ? (
+        <div className="flex flex-col items-center justify-center py-12 text-muted-foreground gap-4">
+          <Globe className="h-12 w-12" />
+          <div className="text-center">
+            <p className="text-sm">No global scripts yet</p>
+            <p className="text-xs mt-1">
+              Global scripts are available in every project&apos;s Development screen.
+            </p>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {globalScripts.map((script) => (
+            <div
+              key={script.id}
+              className={cn(
+                'group flex items-center justify-between p-3 bg-muted/30 rounded-lg border border-border hover:border-primary/50 transition-colors',
+                deleteConfirmId === script.id && 'border-destructive'
+              )}
+            >
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium text-sm">{script.name}</span>
+                  <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded flex items-center gap-1">
+                    <Globe className="h-3 w-3" />
+                    Global
+                  </span>
+                  {script.toggle ? (
+                    <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded flex items-center gap-1">
+                      <Power className="h-3 w-3" />
+                      Toggle
+                    </span>
+                  ) : script.terminals && script.terminals.length > 0 ? (
+                    <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded flex items-center gap-1">
+                      <Layers className="h-3 w-3" />
+                      {script.terminals.length} terminals
+                    </span>
+                  ) : (
+                    script.commands.length > 1 && (
+                      <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                        {script.commands.length} commands
+                      </span>
+                    )
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground font-mono truncate mt-1">
+                  {script.toggle
+                    ? `${script.toggle.firstPressName} / ${script.toggle.secondPressName}`
+                    : script.terminals && script.terminals.length > 0
+                      ? script.terminals.map((t) => t.name).join(', ')
+                      : script.commands.length > 1
+                        ? script.commands.join(' && ')
+                        : script.command}
+                </p>
+              </div>
+
+              <div className="flex items-center gap-1 ml-2">
+                {deleteConfirmId === script.id ? (
+                  <>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => handleDelete(script.id)}
+                      className="text-xs"
+                    >
+                      Confirm
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setDeleteConfirmId(null)}
+                      className="text-xs"
+                    >
+                      Cancel
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 opacity-0 group-hover:opacity-100 transition-opacity"
+                      onClick={() => handleOpenEditForm(script)}
+                      title="Edit script"
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 opacity-0 group-hover:opacity-100 transition-opacity text-destructive hover:text-destructive"
+                      onClick={() => setDeleteConfirmId(script.id)}
+                      title="Delete script"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/components/tools/DevScriptsTool.tsx
+++ b/src/renderer/components/tools/DevScriptsTool.tsx
@@ -20,6 +20,7 @@ import {
   Terminal,
   Layers,
   Power,
+  Globe,
 } from 'lucide-react';
 import { createLogger } from '../../../renderer/utils/logger';
 
@@ -38,6 +39,7 @@ interface DevScriptsToolProps {
 export function DevScriptsTool({ workingDirectory }: DevScriptsToolProps) {
   const {
     scripts: allScripts,
+    globalScripts,
     loading,
     loadScripts,
     saveScript,
@@ -781,7 +783,7 @@ export function DevScriptsTool({ workingDirectory }: DevScriptsToolProps) {
         )}
 
         {/* Scripts List */}
-        {scripts.length === 0 && !isFormOpen ? (
+        {scripts.length === 0 && globalScripts.length === 0 && !isFormOpen ? (
           <div className="flex flex-col items-center justify-center h-full text-muted-foreground gap-4">
             <Code className="h-12 w-12" />
             <div className="text-center">
@@ -887,6 +889,75 @@ export function DevScriptsTool({ workingDirectory }: DevScriptsToolProps) {
                 </div>
               </div>
             ))}
+          </div>
+        )}
+
+        {/* Global Scripts Section */}
+        {globalScripts.length > 0 && (
+          <div className="mt-4">
+            <div className="flex items-center gap-1.5 mb-2">
+              <Globe className="h-3.5 w-3.5 text-muted-foreground" />
+              <span className="text-xs font-medium text-muted-foreground">Global Scripts</span>
+            </div>
+            <div className="space-y-2">
+              {globalScripts.map((script) => (
+                <div
+                  key={script.id}
+                  className="group flex items-center justify-between p-3 bg-muted/20 rounded-lg border border-dashed border-border hover:border-primary/50 transition-colors"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-sm">{script.name}</span>
+                      <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded flex items-center gap-1">
+                        <Globe className="h-3 w-3" />
+                        Global
+                      </span>
+                      {script.toggle ? (
+                        <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded flex items-center gap-1">
+                          <Power className="h-3 w-3" />
+                          Toggle
+                        </span>
+                      ) : script.terminals && script.terminals.length > 0 ? (
+                        <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded flex items-center gap-1">
+                          <Layers className="h-3 w-3" />
+                          {script.terminals.length} terminals
+                        </span>
+                      ) : (
+                        script.commands.length > 1 && (
+                          <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                            {script.commands.length} commands
+                          </span>
+                        )
+                      )}
+                    </div>
+                    <p className="text-xs text-muted-foreground font-mono truncate mt-1">
+                      {script.toggle
+                        ? `${script.toggle.firstPressName} / ${script.toggle.secondPressName}`
+                        : script.terminals && script.terminals.length > 0
+                          ? script.terminals.map((t) => t.name).join(', ')
+                          : script.commands.length > 1
+                            ? script.commands.join(' && ')
+                            : script.command}
+                    </p>
+                  </div>
+
+                  <div className="flex items-center gap-1 ml-2">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 opacity-0 group-hover:opacity-100 transition-opacity"
+                      onClick={() => handleExecute(script)}
+                      title="Run script"
+                    >
+                      <Play className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+              <p className="text-xs text-muted-foreground text-center mt-1">
+                Manage global scripts in Settings
+              </p>
+            </div>
           </div>
         )}
       </div>

--- a/src/renderer/screens/DevelopmentScreen.tsx
+++ b/src/renderer/screens/DevelopmentScreen.tsx
@@ -124,6 +124,7 @@ export function DevelopmentScreen({
   // Dev scripts store
   const {
     scripts: allScripts,
+    globalScripts,
     loadScripts: loadDevScripts,
     toggleStates,
     flipToggleState,
@@ -170,7 +171,8 @@ export function DevelopmentScreen({
   // Toggle script execution: open modal with the current toggle command, then flip state on close
   const handleToggleExecute = useCallback(
     (scriptId: string, command: string) => {
-      const script = devScripts.find((s) => s.id === scriptId);
+      const script =
+        devScripts.find((s) => s.id === scriptId) ?? globalScripts.find((s) => s.id === scriptId);
       if (!script) return;
       // Create a transient script with the toggle command so the modal runs it
       const toggleExecScript: DevScript = {
@@ -183,7 +185,7 @@ export function DevelopmentScreen({
       setExecutingScript(toggleExecScript);
       flipToggleState(scriptId);
     },
-    [devScripts, flipToggleState]
+    [devScripts, globalScripts, flipToggleState]
   );
 
   // Fetch authenticated user on mount
@@ -372,9 +374,19 @@ export function DevelopmentScreen({
           <span className="text-xs text-muted-foreground">{contribution.localPath}</span>
 
           {/* Dev Script buttons */}
-          {devScripts.length > 0 && (
+          {(devScripts.length > 0 || globalScripts.length > 0) && (
             <div className="flex gap-1 ml-2 border-l border-border pl-3">
               {devScripts.map((script) => (
+                <ScriptButton
+                  key={script.id}
+                  script={script}
+                  onClick={() => setExecutingScript(script)}
+                  isToggle={!!script.toggle}
+                  toggleState={toggleStates[script.id]}
+                  onToggleExecute={(command) => handleToggleExecute(script.id, command)}
+                />
+              ))}
+              {globalScripts.map((script) => (
                 <ScriptButton
                   key={script.id}
                   script={script}

--- a/src/renderer/screens/SettingsScreen.tsx
+++ b/src/renderer/screens/SettingsScreen.tsx
@@ -7,6 +7,7 @@ import { SSHRemotesTab } from '../components/settings/SSHRemotesTab';
 import { CodeServerTab } from '../components/settings/CodeServerTab';
 import { AITab } from '../components/settings/AITab';
 import { NotificationsTab } from '../components/settings/NotificationsTab';
+import { GlobalScriptsTab } from '../components/settings/GlobalScriptsTab';
 
 type SettingsTab =
   | 'general'
@@ -15,7 +16,8 @@ type SettingsTab =
   | 'bash-profile'
   | 'ssh-remotes'
   | 'code-server'
-  | 'notifications';
+  | 'notifications'
+  | 'global-scripts';
 
 const tabs: { id: SettingsTab; label: string }[] = [
   { id: 'general', label: 'General' },
@@ -25,6 +27,7 @@ const tabs: { id: SettingsTab; label: string }[] = [
   { id: 'ssh-remotes', label: 'SSH Remotes' },
   { id: 'code-server', label: 'Code Server' },
   { id: 'notifications', label: 'Notifications' },
+  { id: 'global-scripts', label: 'Global Scripts' },
 ];
 
 export function SettingsScreen() {
@@ -71,6 +74,7 @@ export function SettingsScreen() {
         <CodeServerTab settings={settings} onUpdate={updateSettings} />
       )}
       {activeTab === 'notifications' && <NotificationsTab />}
+      {activeTab === 'global-scripts' && <GlobalScriptsTab />}
     </div>
   );
 }

--- a/src/renderer/stores/useDevScriptsStore.ts
+++ b/src/renderer/stores/useDevScriptsStore.ts
@@ -1,9 +1,11 @@
 import { create } from 'zustand';
 import type { DevScript } from '../../main/ipc/channels';
+import { GLOBAL_SCRIPTS_PATH } from '../../main/ipc/channels/types';
 import { ipc } from '../ipc/client';
 
 interface DevScriptsState {
   scripts: DevScript[];
+  globalScripts: DevScript[];
   loading: boolean;
   error: string | null;
   executingScriptId: string | null;
@@ -13,8 +15,11 @@ interface DevScriptsState {
 
   // Actions
   loadScripts: (projectPath: string) => Promise<void>;
+  loadGlobalScripts: () => Promise<void>;
   saveScript: (script: DevScript) => Promise<void>;
   deleteScript: (id: string) => Promise<void>;
+  saveGlobalScript: (script: DevScript) => Promise<void>;
+  deleteGlobalScript: (id: string) => Promise<void>;
   setExecutingScript: (id: string | null) => void;
   setActiveTerminalSession: (sessionId: string | null) => void;
   flipToggleState: (scriptId: string) => void;
@@ -23,6 +28,7 @@ interface DevScriptsState {
 
 export const useDevScriptsStore = create<DevScriptsState>((set, get) => ({
   scripts: [],
+  globalScripts: [],
   loading: false,
   error: null,
   executingScriptId: null,
@@ -32,11 +38,25 @@ export const useDevScriptsStore = create<DevScriptsState>((set, get) => ({
   loadScripts: async (projectPath: string) => {
     set({ loading: true, error: null, toggleStates: {} });
     try {
-      const loaded = await ipc.invoke('dev-scripts:get-all', projectPath);
+      const [loaded, globals] = await Promise.all([
+        ipc.invoke('dev-scripts:get-all', projectPath),
+        ipc.invoke('dev-scripts:get-all', GLOBAL_SCRIPTS_PATH),
+      ]);
       set((state) => ({
         scripts: [...state.scripts.filter((s) => s.projectPath !== projectPath), ...loaded],
+        globalScripts: globals,
         loading: false,
       }));
+    } catch (error) {
+      set({ error: String(error), loading: false });
+    }
+  },
+
+  loadGlobalScripts: async () => {
+    set({ loading: true, error: null });
+    try {
+      const globals = await ipc.invoke('dev-scripts:get-all', GLOBAL_SCRIPTS_PATH);
+      set({ globalScripts: globals, loading: false });
     } catch (error) {
       set({ error: String(error), loading: false });
     }
@@ -72,6 +92,31 @@ export const useDevScriptsStore = create<DevScriptsState>((set, get) => ({
         scripts: [...state.scripts.filter((s) => s.projectPath !== script.projectPath), ...loaded],
         loading: false,
       }));
+    } catch (error) {
+      set({ error: String(error), loading: false });
+      throw error;
+    }
+  },
+
+  saveGlobalScript: async (script: DevScript) => {
+    const globalScript = { ...script, projectPath: GLOBAL_SCRIPTS_PATH };
+    set({ loading: true, error: null });
+    try {
+      await ipc.invoke('dev-scripts:save', globalScript);
+      const globals = await ipc.invoke('dev-scripts:get-all', GLOBAL_SCRIPTS_PATH);
+      set({ globalScripts: globals, loading: false });
+    } catch (error) {
+      set({ error: String(error), loading: false });
+      throw error;
+    }
+  },
+
+  deleteGlobalScript: async (id: string) => {
+    set({ loading: true, error: null });
+    try {
+      await ipc.invoke('dev-scripts:delete', id);
+      const globals = await ipc.invoke('dev-scripts:get-all', GLOBAL_SCRIPTS_PATH);
+      set({ globalScripts: globals, loading: false });
     } catch (error) {
       set({ error: String(error), loading: false });
       throw error;

--- a/tests/mocks/dev-scripts.mock.ts
+++ b/tests/mocks/dev-scripts.mock.ts
@@ -228,6 +228,48 @@ export function devScriptRowToDevScript(row: MockDevScriptRow): DevScript {
   };
 }
 
+// ── Global Script Factory ──────────────────────────────────────────────
+
+export function createMockGlobalDevScript(overrides?: Partial<DevScript>): DevScript {
+  const command = overrides?.command ?? 'npm run format';
+  const commands = overrides?.commands ?? [command];
+  return {
+    id: `global_script_${Date.now()}_test`,
+    projectPath: '__global__',
+    name: 'Format',
+    command,
+    commands,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+export const mockGlobalDevScripts = {
+  format: createMockGlobalDevScript({
+    id: 'global_script_format',
+    name: 'Format',
+    command: 'npm run format',
+    commands: ['npm run format'],
+  }),
+  lint: createMockGlobalDevScript({
+    id: 'global_script_lint',
+    name: 'Global Lint',
+    command: 'npm run lint',
+    commands: ['npm run lint'],
+  }),
+  clean: createMockGlobalDevScript({
+    id: 'global_script_clean',
+    name: 'Clean',
+    command: 'rm -rf node_modules',
+    commands: ['rm -rf node_modules', 'npm install'],
+  }),
+};
+
+export function createMockGlobalDevScriptsList(): DevScript[] {
+  return [mockGlobalDevScripts.format, mockGlobalDevScripts.lint, mockGlobalDevScripts.clean];
+}
+
 // ── Validation Helpers ──────────────────────────────────────────────
 
 export function isValidDevScript(script: unknown): script is DevScript {

--- a/tests/renderer/components/settings/GlobalScriptsTab.test.tsx
+++ b/tests/renderer/components/settings/GlobalScriptsTab.test.tsx
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+  createMockGlobalDevScript,
+  createMockGlobalDevScriptsList,
+} from '../../../mocks/dev-scripts.mock';
+
+// Mock lucide-react
+vi.mock('lucide-react', async () => import('../../../mocks/lucide-react'));
+
+// Mock the store
+const mockLoadGlobalScripts = vi.fn();
+const mockSaveGlobalScript = vi.fn();
+const mockDeleteGlobalScript = vi.fn();
+
+let mockStoreState = {
+  globalScripts: [] as any[],
+  loading: false,
+  error: null as string | null,
+};
+
+vi.mock('../../../../src/renderer/stores/useDevScriptsStore', () => ({
+  useDevScriptsStore: () => ({
+    ...mockStoreState,
+    loadGlobalScripts: mockLoadGlobalScripts,
+    saveGlobalScript: mockSaveGlobalScript,
+    deleteGlobalScript: mockDeleteGlobalScript,
+  }),
+}));
+
+import { GlobalScriptsTab } from '../../../../src/renderer/components/settings/GlobalScriptsTab';
+
+describe('GlobalScriptsTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStoreState = {
+      globalScripts: [],
+      loading: false,
+      error: null,
+    };
+  });
+
+  describe('rendering', () => {
+    it('renders the title and description', () => {
+      render(<GlobalScriptsTab />);
+      expect(screen.getByText('Global Dev Scripts')).toBeDefined();
+      expect(screen.getByText(/Scripts defined here are available in every project/)).toBeDefined();
+    });
+
+    it('renders empty state when no global scripts', () => {
+      render(<GlobalScriptsTab />);
+      expect(screen.getByText('No global scripts yet')).toBeDefined();
+    });
+
+    it('renders the Add Global Script button', () => {
+      render(<GlobalScriptsTab />);
+      expect(screen.getByText('Add Global Script')).toBeDefined();
+    });
+
+    it('renders global scripts list', () => {
+      mockStoreState.globalScripts = createMockGlobalDevScriptsList();
+      render(<GlobalScriptsTab />);
+
+      expect(screen.getByText('Format')).toBeDefined();
+      expect(screen.getByText('Global Lint')).toBeDefined();
+      expect(screen.getByText('Clean')).toBeDefined();
+    });
+
+    it('shows Global badge on each script', () => {
+      mockStoreState.globalScripts = [createMockGlobalDevScript({ id: 'g1', name: 'Lint' })];
+      render(<GlobalScriptsTab />);
+
+      expect(screen.getAllByText('Global').length).toBeGreaterThan(0);
+    });
+
+    it('calls loadGlobalScripts on mount', () => {
+      render(<GlobalScriptsTab />);
+      expect(mockLoadGlobalScripts).toHaveBeenCalled();
+    });
+  });
+
+  describe('form', () => {
+    it('opens add form when Add Global Script is clicked', () => {
+      render(<GlobalScriptsTab />);
+      fireEvent.click(screen.getByText('Add Global Script'));
+      expect(screen.getByText('New Global Script')).toBeDefined();
+    });
+
+    it('shows name input in single mode', () => {
+      render(<GlobalScriptsTab />);
+      fireEvent.click(screen.getByText('Add Global Script'));
+      expect(screen.getByTestId('global-script-name')).toBeDefined();
+    });
+
+    it('shows mode selector buttons', () => {
+      render(<GlobalScriptsTab />);
+      fireEvent.click(screen.getByText('Add Global Script'));
+      expect(screen.getByText('Single')).toBeDefined();
+      expect(screen.getByText('Multi')).toBeDefined();
+      expect(screen.getByText('Toggle')).toBeDefined();
+    });
+
+    it('shows error for empty name on submit', async () => {
+      render(<GlobalScriptsTab />);
+      fireEvent.click(screen.getByText('Add Global Script'));
+      fireEvent.click(screen.getByText('Add Script'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Name is required')).toBeDefined();
+      });
+    });
+
+    it('shows error for empty command on submit', async () => {
+      render(<GlobalScriptsTab />);
+      fireEvent.click(screen.getByText('Add Global Script'));
+
+      // Set name
+      const nameInput = screen.getByTestId('global-script-name');
+      fireEvent.change(nameInput, { target: { value: 'Test Script' } });
+
+      // Submit without command
+      fireEvent.click(screen.getByText('Add Script'));
+
+      await waitFor(() => {
+        expect(screen.getByText('At least one command is required')).toBeDefined();
+      });
+    });
+
+    it('calls saveGlobalScript on valid submit', async () => {
+      mockSaveGlobalScript.mockResolvedValueOnce(undefined);
+
+      render(<GlobalScriptsTab />);
+      fireEvent.click(screen.getByText('Add Global Script'));
+
+      // Fill form
+      fireEvent.change(screen.getByTestId('global-script-name'), {
+        target: { value: 'Build' },
+      });
+      fireEvent.change(screen.getByTestId('global-script-command-0'), {
+        target: { value: 'npm run build' },
+      });
+
+      // Submit
+      fireEvent.click(screen.getByText('Add Script'));
+
+      await waitFor(() => {
+        expect(mockSaveGlobalScript).toHaveBeenCalledWith(
+          expect.objectContaining({
+            projectPath: '__global__',
+            name: 'Build',
+            commands: ['npm run build'],
+          })
+        );
+      });
+    });
+
+    it('closes form on Cancel', () => {
+      render(<GlobalScriptsTab />);
+      fireEvent.click(screen.getByText('Add Global Script'));
+      expect(screen.getByText('New Global Script')).toBeDefined();
+
+      fireEvent.click(screen.getByText('Cancel'));
+      expect(screen.queryByText('New Global Script')).toBeNull();
+    });
+
+    it('shows duplicate name error', async () => {
+      mockStoreState.globalScripts = [createMockGlobalDevScript({ id: 'g1', name: 'Build' })];
+
+      render(<GlobalScriptsTab />);
+      fireEvent.click(screen.getByText('Add Global Script'));
+
+      fireEvent.change(screen.getByTestId('global-script-name'), {
+        target: { value: 'Build' },
+      });
+      fireEvent.change(screen.getByTestId('global-script-command-0'), {
+        target: { value: 'npm run build' },
+      });
+      fireEvent.click(screen.getByText('Add Script'));
+
+      await waitFor(() => {
+        expect(screen.getByText('A global script with this name already exists')).toBeDefined();
+      });
+    });
+  });
+
+  describe('delete', () => {
+    it('shows delete confirmation on delete click', () => {
+      mockStoreState.globalScripts = [createMockGlobalDevScript({ id: 'g1', name: 'Build' })];
+
+      render(<GlobalScriptsTab />);
+
+      // Find and click delete button
+      const deleteBtn = screen.getByTitle('Delete script');
+      fireEvent.click(deleteBtn);
+
+      expect(screen.getByText('Confirm')).toBeDefined();
+    });
+
+    it('calls deleteGlobalScript on confirm', async () => {
+      mockDeleteGlobalScript.mockResolvedValueOnce(undefined);
+      mockStoreState.globalScripts = [createMockGlobalDevScript({ id: 'g1', name: 'Build' })];
+
+      render(<GlobalScriptsTab />);
+
+      fireEvent.click(screen.getByTitle('Delete script'));
+      fireEvent.click(screen.getByText('Confirm'));
+
+      await waitFor(() => {
+        expect(mockDeleteGlobalScript).toHaveBeenCalledWith('g1');
+      });
+    });
+  });
+});

--- a/tests/renderer/components/tools/DevScriptsTool.test.tsx
+++ b/tests/renderer/components/tools/DevScriptsTool.test.tsx
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { createMockDevScript, createMockToggleScript } from '../../../mocks/dev-scripts.mock';
+import {
+  createMockDevScript,
+  createMockToggleScript,
+  createMockGlobalDevScript,
+  createMockGlobalDevScriptsList,
+} from '../../../mocks/dev-scripts.mock';
 
 // Mock lucide-react
 vi.mock('lucide-react', async () => import('../../../mocks/lucide-react'));
@@ -20,6 +25,7 @@ const mockDeleteScript = vi.fn();
 
 let mockStoreState = {
   scripts: [] as any[],
+  globalScripts: [] as any[],
   loading: false,
   error: null as string | null,
 };
@@ -46,6 +52,7 @@ describe('DevScriptsTool', () => {
     vi.clearAllMocks();
     mockStoreState = {
       scripts: [],
+      globalScripts: [],
       loading: false,
       error: null,
     };
@@ -776,6 +783,92 @@ describe('DevScriptsTool', () => {
       render(<DevScriptsTool {...defaultProps} />);
       expect(screen.getByText('My Build')).toBeDefined();
       expect(screen.queryByText('Other Build')).toBeNull();
+    });
+  });
+
+  describe('global scripts display', () => {
+    it('should show global scripts section when globals exist', () => {
+      mockStoreState.globalScripts = createMockGlobalDevScriptsList();
+
+      render(<DevScriptsTool {...defaultProps} />);
+      expect(screen.getByText('Global Scripts')).toBeDefined();
+    });
+
+    it('should not show global scripts section when no globals', () => {
+      mockStoreState.globalScripts = [];
+
+      render(<DevScriptsTool {...defaultProps} />);
+      expect(screen.queryByText('Global Scripts')).toBeNull();
+    });
+
+    it('should show Global badge on global scripts', () => {
+      mockStoreState.globalScripts = [createMockGlobalDevScript({ id: 'g1', name: 'Format' })];
+
+      render(<DevScriptsTool {...defaultProps} />);
+      expect(screen.getByText('Format')).toBeDefined();
+      expect(screen.getAllByText('Global').length).toBeGreaterThan(0);
+    });
+
+    it('should show global scripts alongside project scripts', () => {
+      mockStoreState.scripts = [
+        createMockDevScript({
+          id: 'p1',
+          name: 'Build',
+          projectPath: '/test/project/path',
+        }),
+      ];
+      mockStoreState.globalScripts = [createMockGlobalDevScript({ id: 'g1', name: 'Format' })];
+
+      render(<DevScriptsTool {...defaultProps} />);
+      expect(screen.getByText('Build')).toBeDefined();
+      expect(screen.getByText('Format')).toBeDefined();
+      expect(screen.getByText('Global Scripts')).toBeDefined();
+    });
+
+    it('should show manage hint for global scripts', () => {
+      mockStoreState.globalScripts = [createMockGlobalDevScript({ id: 'g1', name: 'Format' })];
+
+      render(<DevScriptsTool {...defaultProps} />);
+      expect(screen.getByText('Manage global scripts in Settings')).toBeDefined();
+    });
+
+    it('should not show empty state when only global scripts exist', () => {
+      mockStoreState.scripts = [];
+      mockStoreState.globalScripts = [createMockGlobalDevScript({ id: 'g1', name: 'Format' })];
+
+      render(<DevScriptsTool {...defaultProps} />);
+      expect(screen.queryByText('No scripts yet')).toBeNull();
+    });
+
+    it('should dispatch execute event when global script run is clicked', async () => {
+      const globalScript = createMockGlobalDevScript({ id: 'g1', name: 'Format' });
+      mockStoreState.globalScripts = [globalScript];
+
+      const eventListener = vi.fn();
+      window.addEventListener('execute-dev-script', eventListener);
+
+      const { container } = render(<DevScriptsTool {...defaultProps} />);
+
+      // Global scripts have a run button
+      const runButton = container.querySelector('button[title="Run script"]');
+      expect(runButton).not.toBeNull();
+      fireEvent.click(runButton!);
+
+      await waitFor(() => {
+        expect(eventListener).toHaveBeenCalled();
+      });
+
+      window.removeEventListener('execute-dev-script', eventListener);
+    });
+
+    it('should not show edit or delete buttons for global scripts', () => {
+      mockStoreState.globalScripts = [createMockGlobalDevScript({ id: 'g1', name: 'Format' })];
+
+      const { container } = render(<DevScriptsTool {...defaultProps} />);
+
+      // Global scripts should only have Run button, no Edit or Delete
+      expect(container.querySelector('button[title="Edit script"]')).toBeNull();
+      expect(container.querySelector('button[title="Delete script"]')).toBeNull();
     });
   });
 });

--- a/tests/renderer/components/tools/ToolsPanel.test.tsx
+++ b/tests/renderer/components/tools/ToolsPanel.test.tsx
@@ -44,6 +44,7 @@ vi.mock('../../../../src/renderer/components/tools/XTermTerminal', () => ({
 vi.mock('../../../../src/renderer/stores/useDevScriptsStore', () => ({
   useDevScriptsStore: () => ({
     scripts: [],
+    globalScripts: [],
     loading: false,
     loadScripts: vi.fn(),
     saveScript: vi.fn(),

--- a/tests/renderer/screens/DevelopmentScreen.dev-scripts.test.tsx
+++ b/tests/renderer/screens/DevelopmentScreen.dev-scripts.test.tsx
@@ -35,6 +35,7 @@ const mockElectronAPI = {
 // Mock the dev scripts store
 let mockDevScriptsState = {
   scripts: [] as any[],
+  globalScripts: [] as any[],
   loading: false,
   error: null as string | null,
   loadScripts: vi.fn(),
@@ -121,6 +122,7 @@ describe('DevelopmentScreen Dev Scripts Integration', () => {
     vi.clearAllMocks();
     mockDevScriptsState = {
       scripts: [],
+      globalScripts: [],
       loading: false,
       error: null,
       loadScripts: vi.fn(),

--- a/tests/renderer/screens/DevelopmentScreen.toggle.test.tsx
+++ b/tests/renderer/screens/DevelopmentScreen.toggle.test.tsx
@@ -136,6 +136,7 @@ describe('DevelopmentScreen Toggle Integration', () => {
     mockToggleStates = {};
     mockDevScriptsState = {
       scripts: [toggleScript],
+      globalScripts: [],
       loading: false,
       error: null,
       executingScriptId: null,

--- a/tests/renderer/screens/DevelopmentScreen.toolbar.test.tsx
+++ b/tests/renderer/screens/DevelopmentScreen.toolbar.test.tsx
@@ -41,6 +41,7 @@ vi.mock('../../../src/renderer/components/branches/BranchDetailModal', () => ({
 vi.mock('../../../src/renderer/stores/useDevScriptsStore', () => ({
   useDevScriptsStore: () => ({
     scripts: [],
+    globalScripts: [],
     loading: false,
     loadScripts: vi.fn(),
     saveScript: vi.fn(),

--- a/tests/renderer/screens/DevelopmentScreen.tools.test.tsx
+++ b/tests/renderer/screens/DevelopmentScreen.tools.test.tsx
@@ -56,6 +56,7 @@ vi.mock('../../../src/renderer/components/tools/ToolsPanel', () => ({
 vi.mock('../../../src/renderer/stores/useDevScriptsStore', () => ({
   useDevScriptsStore: () => ({
     scripts: [],
+    globalScripts: [],
     loading: false,
     loadScripts: vi.fn(),
     saveScript: vi.fn(),

--- a/tests/renderer/stores/useDevScriptsStore.test.ts
+++ b/tests/renderer/stores/useDevScriptsStore.test.ts
@@ -24,6 +24,7 @@ describe('useDevScriptsStore', () => {
     // Reset store to initial state
     useDevScriptsStore.setState({
       scripts: [],
+      globalScripts: [],
       loading: false,
       error: null,
       executingScriptId: null,
@@ -84,13 +85,16 @@ describe('useDevScriptsStore', () => {
 
     it('should populate scripts from IPC response', async () => {
       const mockScripts = createMockDevScriptsList();
-      mockInvoke.mockResolvedValueOnce(mockScripts);
+      // loadScripts now calls Promise.all with project path + __global__
+      mockInvoke.mockResolvedValueOnce(mockScripts); // project scripts
+      mockInvoke.mockResolvedValueOnce([]); // global scripts
 
       await act(async () => {
         await useDevScriptsStore.getState().loadScripts('/test/project');
       });
 
       expect(mockInvoke).toHaveBeenCalledWith('dev-scripts:get-all', '/test/project');
+      expect(mockInvoke).toHaveBeenCalledWith('dev-scripts:get-all', '__global__');
       expect(useDevScriptsStore.getState().scripts).toHaveLength(3);
     });
 
@@ -105,7 +109,8 @@ describe('useDevScriptsStore', () => {
     });
 
     it('should set loading false after completion', async () => {
-      mockInvoke.mockResolvedValueOnce([]);
+      mockInvoke.mockResolvedValueOnce([]); // project
+      mockInvoke.mockResolvedValueOnce([]); // global
 
       await act(async () => {
         await useDevScriptsStore.getState().loadScripts('/test/project');
@@ -128,13 +133,31 @@ describe('useDevScriptsStore', () => {
       // Set initial error state
       useDevScriptsStore.setState({ error: 'Previous error' });
 
-      mockInvoke.mockResolvedValueOnce([]);
+      mockInvoke.mockResolvedValueOnce([]); // project
+      mockInvoke.mockResolvedValueOnce([]); // global
 
       await act(async () => {
         await useDevScriptsStore.getState().loadScripts('/test/project');
       });
 
       expect(useDevScriptsStore.getState().error).toBeNull();
+    });
+
+    it('should also load global scripts alongside project scripts', async () => {
+      const mockScripts = createMockDevScriptsList();
+      const mockGlobals = [
+        createMockDevScript({ id: 'global_1', projectPath: '__global__', name: 'Format' }),
+      ];
+      mockInvoke.mockResolvedValueOnce(mockScripts); // project
+      mockInvoke.mockResolvedValueOnce(mockGlobals); // global
+
+      await act(async () => {
+        await useDevScriptsStore.getState().loadScripts('/test/project');
+      });
+
+      expect(useDevScriptsStore.getState().scripts).toHaveLength(3);
+      expect(useDevScriptsStore.getState().globalScripts).toHaveLength(1);
+      expect(useDevScriptsStore.getState().globalScripts[0].name).toBe('Format');
     });
   });
 
@@ -460,7 +483,8 @@ describe('useDevScriptsStore', () => {
         toggleStates: { script_1: true, script_2: false },
       });
 
-      mockInvoke.mockResolvedValueOnce([]);
+      mockInvoke.mockResolvedValueOnce([]); // project
+      mockInvoke.mockResolvedValueOnce([]); // global
 
       await act(async () => {
         await useDevScriptsStore.getState().loadScripts('/test/project');
@@ -478,6 +502,7 @@ describe('useDevScriptsStore', () => {
         ...s,
         projectPath: '/test/project',
       }));
+      // Each loadScripts call makes 2 IPC calls (project + global)
       mockInvoke.mockResolvedValue(scripts);
 
       await act(async () => {
@@ -488,7 +513,7 @@ describe('useDevScriptsStore', () => {
         await useDevScriptsStore.getState().loadScripts('/test/project');
       });
 
-      expect(mockInvoke).toHaveBeenCalledTimes(2);
+      expect(mockInvoke).toHaveBeenCalledTimes(4); // 2 calls x 2 loads
       expect(useDevScriptsStore.getState().scripts).toHaveLength(3);
     });
 
@@ -496,7 +521,8 @@ describe('useDevScriptsStore', () => {
       const scripts1 = [createMockDevScript({ id: 'a1', projectPath: '/project/one' })];
       const scripts2 = [createMockDevScript({ id: 'b1', projectPath: '/project/two' })];
 
-      mockInvoke.mockResolvedValueOnce(scripts1);
+      mockInvoke.mockResolvedValueOnce(scripts1); // project one
+      mockInvoke.mockResolvedValueOnce([]); // global
 
       await act(async () => {
         await useDevScriptsStore.getState().loadScripts('/project/one');
@@ -504,7 +530,8 @@ describe('useDevScriptsStore', () => {
 
       expect(useDevScriptsStore.getState().scripts).toEqual(scripts1);
 
-      mockInvoke.mockResolvedValueOnce(scripts2);
+      mockInvoke.mockResolvedValueOnce(scripts2); // project two
+      mockInvoke.mockResolvedValueOnce([]); // global
 
       await act(async () => {
         await useDevScriptsStore.getState().loadScripts('/project/two');
@@ -518,7 +545,8 @@ describe('useDevScriptsStore', () => {
     });
 
     it('should handle empty scripts array', async () => {
-      mockInvoke.mockResolvedValueOnce([]);
+      mockInvoke.mockResolvedValueOnce([]); // project
+      mockInvoke.mockResolvedValueOnce([]); // global
 
       await act(async () => {
         await useDevScriptsStore.getState().loadScripts('/empty/project');
@@ -541,7 +569,8 @@ describe('useDevScriptsStore', () => {
       const updatedA = [
         createMockDevScript({ id: 'a2', projectPath: '/project/a', name: 'New A' }),
       ];
-      mockInvoke.mockResolvedValueOnce(updatedA);
+      mockInvoke.mockResolvedValueOnce(updatedA); // project
+      mockInvoke.mockResolvedValueOnce([]); // global
 
       await act(async () => {
         await useDevScriptsStore.getState().loadScripts('/project/a');
@@ -599,7 +628,8 @@ describe('useDevScriptsStore', () => {
         activeTerminalSession: 'active_session',
       });
 
-      mockInvoke.mockResolvedValueOnce([]);
+      mockInvoke.mockResolvedValueOnce([]); // project
+      mockInvoke.mockResolvedValueOnce([]); // global
 
       await act(async () => {
         await useDevScriptsStore.getState().loadScripts('/test/project');
@@ -612,6 +642,124 @@ describe('useDevScriptsStore', () => {
   });
 
   // ── selectScriptsForProject ──────────────────────────────────────────
+
+  // ── Global Scripts ──────────────────────────────────────────
+
+  describe('loadGlobalScripts', () => {
+    it('should fetch scripts with __global__ path', async () => {
+      const globals = [
+        createMockDevScript({ id: 'g1', projectPath: '__global__', name: 'Format' }),
+      ];
+      mockInvoke.mockResolvedValueOnce(globals);
+
+      await act(async () => {
+        await useDevScriptsStore.getState().loadGlobalScripts();
+      });
+
+      expect(mockInvoke).toHaveBeenCalledWith('dev-scripts:get-all', '__global__');
+      expect(useDevScriptsStore.getState().globalScripts).toHaveLength(1);
+      expect(useDevScriptsStore.getState().globalScripts[0].name).toBe('Format');
+    });
+
+    it('should set loading during fetch', async () => {
+      let resolvePromise: (value: unknown) => void;
+      const controlledPromise = new Promise((resolve) => {
+        resolvePromise = resolve;
+      });
+      mockInvoke.mockReturnValue(controlledPromise);
+
+      const loadPromise = act(async () => {
+        useDevScriptsStore.getState().loadGlobalScripts();
+      });
+
+      expect(useDevScriptsStore.getState().loading).toBe(true);
+
+      resolvePromise!([]);
+      await loadPromise;
+
+      expect(useDevScriptsStore.getState().loading).toBe(false);
+    });
+
+    it('should set error on failure', async () => {
+      mockInvoke.mockRejectedValueOnce(new Error('Global load failed'));
+
+      await act(async () => {
+        await useDevScriptsStore.getState().loadGlobalScripts();
+      });
+
+      expect(useDevScriptsStore.getState().error).toContain('Global load failed');
+    });
+  });
+
+  describe('saveGlobalScript', () => {
+    it('should set projectPath to __global__ and save', async () => {
+      const script = createMockDevScript({ id: 'g1', name: 'Format' });
+      const savedGlobal = { ...script, projectPath: '__global__' };
+      mockInvoke.mockResolvedValueOnce(undefined); // save
+      mockInvoke.mockResolvedValueOnce([savedGlobal]); // reload
+
+      await act(async () => {
+        await useDevScriptsStore.getState().saveGlobalScript(script);
+      });
+
+      expect(mockInvoke).toHaveBeenCalledWith(
+        'dev-scripts:save',
+        expect.objectContaining({ projectPath: '__global__' })
+      );
+      expect(mockInvoke).toHaveBeenCalledWith('dev-scripts:get-all', '__global__');
+      expect(useDevScriptsStore.getState().globalScripts).toHaveLength(1);
+    });
+
+    it('should set error on save failure', async () => {
+      mockInvoke.mockRejectedValueOnce(new Error('Save failed'));
+
+      await expect(
+        act(async () => {
+          await useDevScriptsStore.getState().saveGlobalScript(createMockDevScript({ id: 'g1' }));
+        })
+      ).rejects.toThrow('Save failed');
+
+      expect(useDevScriptsStore.getState().error).toContain('Save failed');
+    });
+  });
+
+  describe('deleteGlobalScript', () => {
+    it('should delete and reload global scripts', async () => {
+      useDevScriptsStore.setState({
+        globalScripts: [
+          createMockDevScript({ id: 'g1', projectPath: '__global__', name: 'Format' }),
+        ],
+      });
+
+      mockInvoke.mockResolvedValueOnce(undefined); // delete
+      mockInvoke.mockResolvedValueOnce([]); // reload
+
+      await act(async () => {
+        await useDevScriptsStore.getState().deleteGlobalScript('g1');
+      });
+
+      expect(mockInvoke).toHaveBeenCalledWith('dev-scripts:delete', 'g1');
+      expect(mockInvoke).toHaveBeenCalledWith('dev-scripts:get-all', '__global__');
+      expect(useDevScriptsStore.getState().globalScripts).toHaveLength(0);
+    });
+
+    it('should not affect project scripts on global delete', async () => {
+      useDevScriptsStore.setState({
+        scripts: [createMockDevScript({ id: 'p1', projectPath: '/project/a' })],
+        globalScripts: [createMockDevScript({ id: 'g1', projectPath: '__global__' })],
+      });
+
+      mockInvoke.mockResolvedValueOnce(undefined); // delete
+      mockInvoke.mockResolvedValueOnce([]); // reload global
+
+      await act(async () => {
+        await useDevScriptsStore.getState().deleteGlobalScript('g1');
+      });
+
+      expect(useDevScriptsStore.getState().scripts).toHaveLength(1);
+      expect(useDevScriptsStore.getState().scripts[0].id).toBe('p1');
+    });
+  });
 
   describe('selectScriptsForProject', () => {
     it('should return only scripts matching the given projectPath', () => {


### PR DESCRIPTION
## Summary

- Add Global Dev Scripts settings tab for creating dev scripts accessible by all projects
- Global scripts use a `__global__` sentinel path, reusing existing `dev_scripts` table and IPC channels with zero schema migration
- Global script buttons appear in the Development screen header bar alongside project-specific scripts for one-click execution from any project
- Global scripts also appear in the DevScriptsTool panel with Globe badge, dashed borders, and run-only controls

## Changes

**New Files**
- `src/renderer/components/settings/GlobalScriptsTab.tsx` — full CRUD settings tab with Single, Multi-Terminal, and Toggle mode forms
- `tests/renderer/components/settings/GlobalScriptsTab.test.tsx` — 14 tests covering rendering, form validation, submit, and delete flows

**Modified Files**
- `src/main/ipc/channels/types.ts` — add `GLOBAL_SCRIPTS_PATH` constant (`__global__`)
- `src/renderer/stores/useDevScriptsStore.ts` — add `globalScripts` state, `loadGlobalScripts()`, `saveGlobalScript()`, `deleteGlobalScript()` actions; `loadScripts()` now fetches both project + global scripts in parallel via `Promise.all`
- `src/renderer/screens/SettingsScreen.tsx` — add Global Scripts tab
- `src/renderer/screens/DevelopmentScreen.tsx` — render global script buttons in header bar, support toggle execution for global scripts
- `src/renderer/components/tools/DevScriptsTool.tsx` — add Global Scripts section with Globe badge, dashed-border cards, run-only buttons, and "Manage global scripts in Settings" hint