### PR TITLE
Feat/55 New Project Functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **New Project Wizard** — interactive multi-step wizard for creating new projects from My Projects and Professional Projects screens (#55)
+  - **6-step guided wizard**: Basics (name, location, type) > Ecosystem (7 ecosystems, frameworks, monorepo tools, package managers) > Options (GitHub repo, extras, license) > Database (5 engines, ORM selection, Docker Compose, env vars) > GitHub Config (template selection from 12 existing templates) > Review & Create (summary + live progress)
+  - **CLI Detection Service** (`cli-detection.service.ts`): detects installed CLI tools per ecosystem with version info, required/optional classification, and monorepo tool support
+  - **Project Scaffold Service** (`project-scaffold.service.ts`): orchestrates project creation via ecosystem-specific CLI commands (npm create vite, cargo init, go mod init, rails new, etc.) with manual fallbacks, extras writing (.gitignore, .editorconfig, LICENSE, README), and monorepo setup (Turborepo, Nx, pnpm/Cargo/Go/uv workspaces)
+  - **Database Scaffold Service** (`database-scaffold.service.ts`): generates Docker Compose configs, environment variables, and Prisma schemas for PostgreSQL, MySQL, MongoDB, SQLite, and Redis with ORM options across 7 ecosystems
+  - **Template files**: per-ecosystem `.gitignore` templates and 6 open-source license templates (MIT, Apache-2.0, GPL-3.0, BSD-2-Clause, ISC, Unlicense)
+  - **GitHub repo creation**: `createRepository()` added to GitHub REST service for creating new repos via API
+  - **Smart package manager validation**: pre-flight check when leaving Ecosystem step detects if selected PM (bun, pnpm, yarn, uv, poetry) is installed; inline banner offers to switch to an installed alternative, install the tool globally, or continue anyway; auto-advances after successful install
+  - **8 new IPC channels**: `project:check-cli-tools`, `project:scaffold`, `project:scaffold-database`, `project:get-orm-options`, `project:create-github-repo`, `project:initialize-git`, `project:validate-package-manager`, `project:install-tool`
+  - **Database schema v9**: 7 new columns on contributions table (ecosystem, framework, package_manager, is_monorepo, monorepo_tool, database_engine, database_orm) for project metadata persistence
+  - **Creation pipeline**: validates CLI tools > creates directory > scaffolds project > scaffolds database > applies GitHub config templates > git init with main+dev branches > creates GitHub repo > pushes > saves to DB > auto-opens in Development screen
+  - **"New Project" button** on both My Projects and Professional Projects screens with auto-filled category and default location from settings
 - **GitHub Config Tool** — 7th tool in ToolsPanel for managing `.github/` directory configurations
   - **Dev Tools-style layout**: two category sections (Repository + Community) with icon headers, bordered cards, and 64px feature buttons with green/grey status dots — matching MaintenanceTool pattern
   - **GitHubConfigService** (`github-config.service.ts`): file system service for scanning, reading, writing, deleting, and deploying `.github/` configs with 12 feature templates and YAML front-matter parser

--- a/src/main/database/database.service.ts
+++ b/src/main/database/database.service.ts
@@ -28,6 +28,13 @@ interface ContributionRow {
   upstream_url: string | null;
   is_fork: number | null;
   remotes_valid: number | null;
+  ecosystem: string | null;
+  framework: string | null;
+  package_manager: string | null;
+  is_monorepo: number | null;
+  monorepo_tool: string | null;
+  database_engine: string | null;
+  database_orm: string | null;
 }
 
 /**
@@ -133,9 +140,9 @@ export class DatabaseService {
     const stmt = db.prepare(`
       INSERT INTO contributions (
         id, repository_url, local_path, issue_number, issue_title, branch_name, status,
-        created_at, updated_at, pr_url, pr_number, pr_status, upstream_url, is_fork, remotes_valid, type
+        created_at, updated_at, pr_url, pr_number, pr_status, upstream_url, is_fork, remotes_valid, type, ecosystem, framework, package_manager, is_monorepo, monorepo_tool, database_engine, database_orm
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     stmt.run(
@@ -154,7 +161,14 @@ export class DatabaseService {
       contribution.upstreamUrl || null,
       contribution.isFork ? 1 : 0,
       contribution.remotesValid ? 1 : 0,
-      contribution.type || 'contribution'
+      contribution.type || 'contribution',
+      contribution.ecosystem || null,
+      contribution.framework || null,
+      contribution.packageManager || null,
+      contribution.isMonorepo ? 1 : 0,
+      contribution.monorepoTool || null,
+      contribution.databaseEngine || null,
+      contribution.databaseOrm || null
     );
 
     return {
@@ -208,7 +222,7 @@ export class DatabaseService {
       UPDATE contributions
       SET repository_url = ?, local_path = ?, issue_number = ?, issue_title = ?, branch_name = ?, status = ?,
           pr_url = ?, pr_number = ?, pr_status = ?, upstream_url = ?, is_fork = ?, remotes_valid = ?,
-          created_at = ?, updated_at = ?, type = ?
+          created_at = ?, updated_at = ?, type = ?, ecosystem = ?, framework = ?, package_manager = ?, is_monorepo = ?, monorepo_tool = ?, database_engine = ?, database_orm = ?
       WHERE id = ?
     `);
 
@@ -228,6 +242,13 @@ export class DatabaseService {
       createdAtTimestamp,
       now,
       merged.type || 'contribution',
+      merged.ecosystem || null,
+      merged.framework || null,
+      merged.packageManager || null,
+      merged.isMonorepo ? 1 : 0,
+      merged.monorepoTool || null,
+      merged.databaseEngine || null,
+      merged.databaseOrm || null,
       id
     );
 
@@ -379,6 +400,13 @@ export class DatabaseService {
       upstreamUrl: row.upstream_url || undefined,
       isFork: row.is_fork === 1,
       remotesValid: row.remotes_valid === 1,
+      ecosystem: row.ecosystem || undefined,
+      framework: row.framework || undefined,
+      packageManager: row.package_manager || undefined,
+      isMonorepo: row.is_monorepo === 1,
+      monorepoTool: row.monorepo_tool || undefined,
+      databaseEngine: row.database_engine || undefined,
+      databaseOrm: row.database_orm || undefined,
     };
   }
 

--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -4,7 +4,7 @@
  * SQLite database schema for Cola Records
  */
 
-export const SCHEMA_VERSION = 8;
+export const SCHEMA_VERSION = 9;
 
 /**
  * SQL statements to create all tables
@@ -118,5 +118,15 @@ export const MIGRATIONS: Record<number, string> = {
     CREATE INDEX IF NOT EXISTS idx_notifications_read ON notifications(read);
     CREATE INDEX IF NOT EXISTS idx_notifications_dedupe_key ON notifications(dedupe_key);
     CREATE INDEX IF NOT EXISTS idx_notifications_category ON notifications(category);
+  `,
+  // Version 9: Add project creation metadata columns
+  9: `
+    ALTER TABLE contributions ADD COLUMN ecosystem TEXT;
+    ALTER TABLE contributions ADD COLUMN framework TEXT;
+    ALTER TABLE contributions ADD COLUMN package_manager TEXT;
+    ALTER TABLE contributions ADD COLUMN is_monorepo INTEGER DEFAULT 0;
+    ALTER TABLE contributions ADD COLUMN monorepo_tool TEXT;
+    ALTER TABLE contributions ADD COLUMN database_engine TEXT;
+    ALTER TABLE contributions ADD COLUMN database_orm TEXT;
   `,
 };

--- a/src/main/ipc/channels/core.channels.ts
+++ b/src/main/ipc/channels/core.channels.ts
@@ -63,6 +63,13 @@ import type {
   GitHubConfigScanResult,
   GitHubConfigTemplate,
   GitHubConfigIssueTemplate,
+  ToolDetectionResult,
+  ToolInstallResult,
+  ScaffoldConfig,
+  ScaffoldResult,
+  DatabaseScaffoldConfig,
+  ORMOption,
+  GitHubRepository,
 } from './types';
 
 export interface CoreChannels {
@@ -92,6 +99,24 @@ export interface CoreChannels {
 
   // Project Channels
   'project:scan-directory': (directoryPath: string) => Contribution[];
+  'project:check-cli-tools': (
+    ecosystem: Ecosystem,
+    isMonorepo?: boolean,
+    monorepoTool?: string
+  ) => ToolDetectionResult[];
+  'project:scaffold': (config: ScaffoldConfig) => ScaffoldResult;
+  'project:scaffold-database': (config: DatabaseScaffoldConfig) => ScaffoldResult;
+  'project:get-orm-options': (ecosystem: Ecosystem, engine: string) => ORMOption[];
+  'project:create-github-repo': (
+    name: string,
+    options: { description?: string; isPrivate?: boolean; autoInit?: boolean }
+  ) => GitHubRepository;
+  'project:initialize-git': (projectPath: string, remoteName?: string, remoteUrl?: string) => void;
+  'project:validate-package-manager': (
+    ecosystem: Ecosystem,
+    packageManager: string
+  ) => ToolDetectionResult;
+  'project:install-tool': (toolName: string) => ToolInstallResult;
 
   // Settings Channels
   'settings:get': () => AppSettings;

--- a/src/main/ipc/channels/types.ts
+++ b/src/main/ipc/channels/types.ts
@@ -185,6 +185,14 @@ export interface Contribution {
   upstreamUrl?: string;
   isFork?: boolean;
   remotesValid?: boolean;
+  // Project creation metadata
+  ecosystem?: string;
+  framework?: string;
+  packageManager?: string;
+  isMonorepo?: boolean;
+  monorepoTool?: string;
+  databaseEngine?: string;
+  databaseOrm?: string;
 }
 
 // Spotify Types
@@ -504,6 +512,15 @@ export interface DiskUsageResult {
   totalBytes: number;
   entries: DiskUsageEntry[];
   scanDurationMs: number;
+}
+
+// CLI Detection Types
+export interface ToolDetectionResult {
+  name: string;
+  installed: boolean;
+  version?: string;
+  path?: string;
+  required: boolean;
 }
 
 // Hook Tool Types
@@ -989,4 +1006,95 @@ export interface NotificationPreferences {
   dndEnabled: boolean;
   pollInterval: number;
   categories: Record<NotificationCategory, NotificationCategoryPreference>;
+}
+
+// Project Creation Types
+export interface ToolDetectionResult {
+  name: string;
+  installed: boolean;
+  version?: string;
+  path?: string;
+  required: boolean;
+}
+
+export interface ToolInstallResult {
+  success: boolean;
+  message: string;
+  version?: string;
+}
+
+export interface ScaffoldConfig {
+  projectName: string;
+  projectPath: string;
+  ecosystem: Ecosystem;
+  framework?: string;
+  packageManager?: string;
+  isMonorepo: boolean;
+  monorepoTool?: string;
+  extras: {
+    gitignore: boolean;
+    editorconfig: boolean;
+    envFile: boolean;
+    readme: boolean;
+    license?: string;
+  };
+}
+
+export interface ScaffoldResult {
+  success: boolean;
+  message: string;
+  filesCreated: string[];
+  warnings: string[];
+}
+
+export interface DatabaseScaffoldConfig {
+  projectPath: string;
+  projectName: string;
+  ecosystem: Ecosystem;
+  engine: 'postgresql' | 'mysql' | 'mongodb' | 'sqlite' | 'redis' | 'none';
+  orm?: string;
+  includeDocker: boolean;
+  includeEnvVars: boolean;
+  additionalEngines: string[];
+}
+
+export interface ORMOption {
+  id: string;
+  name: string;
+  recommended: boolean;
+}
+
+export interface ProjectGitHubConfigSelection {
+  featureId: string;
+  templateId: string;
+}
+
+export interface WizardConfig {
+  projectName: string;
+  category: 'personal' | 'professional';
+  location: string;
+  projectType: 'single' | 'monorepo';
+  ecosystem: Ecosystem;
+  framework?: string;
+  monorepoTool?: string;
+  packageManager: string;
+  createGitHubRepo: boolean;
+  repoVisibility: 'public' | 'private';
+  repoDescription: string;
+  extras: {
+    gitignore: boolean;
+    editorconfig: boolean;
+    readme: boolean;
+    envFile: boolean;
+    hooks: boolean;
+    license: string | null;
+  };
+  database: {
+    engine: 'postgresql' | 'mysql' | 'mongodb' | 'sqlite' | 'redis' | 'none';
+    orm?: string;
+    includeDocker: boolean;
+    includeEnvVars: boolean;
+    additionalEngines: string[];
+  };
+  githubConfigSelections: ProjectGitHubConfigSelection[];
 }

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -137,6 +137,14 @@ export function removeAllIpcHandlers(): void {
     'contribution:sync-with-github',
     // ── Projects ──
     'project:scan-directory',
+    'project:check-cli-tools',
+    'project:scaffold',
+    'project:scaffold-database',
+    'project:get-orm-options',
+    'project:create-github-repo',
+    'project:initialize-git',
+    'project:validate-package-manager',
+    'project:install-tool',
     // ── Settings ──
     'settings:get',
     'settings:update',

--- a/src/main/ipc/handlers/index.ts
+++ b/src/main/ipc/handlers/index.ts
@@ -14,6 +14,7 @@ import { setupAIHandlers } from './ai.handlers';
 import { setupWorkflowHandlers } from './workflow.handlers';
 import { setupNotificationHandlers } from './notification.handlers';
 import { setupGitHubConfigHandlers } from './github-config.handlers';
+import { setupProjectHandlers } from './project.handlers';
 
 export function setupIpcHandlers(): void {
   setupGitHubHandlers();
@@ -26,4 +27,5 @@ export function setupIpcHandlers(): void {
   setupWorkflowHandlers();
   setupNotificationHandlers();
   setupGitHubConfigHandlers();
+  setupProjectHandlers();
 }

--- a/src/main/ipc/handlers/project.handlers.ts
+++ b/src/main/ipc/handlers/project.handlers.ts
@@ -1,0 +1,60 @@
+/**
+ * Project IPC Handlers
+ *
+ * Registers handlers for: project:check-cli-tools, project:scaffold,
+ * project:scaffold-database, project:get-orm-options,
+ * project:create-github-repo, project:initialize-git,
+ * project:validate-package-manager, project:install-tool
+ */
+import { handleIpc } from '../handlers';
+
+export function setupProjectHandlers(): void {
+  handleIpc('project:check-cli-tools', async (_event, ecosystem, isMonorepo, monorepoTool) => {
+    const { cliDetectionService } = await import('../../services/cli-detection.service');
+    return cliDetectionService.detectEcosystemTools(ecosystem, isMonorepo, monorepoTool);
+  });
+
+  handleIpc('project:validate-package-manager', async (_event, _ecosystem, packageManager) => {
+    const { cliDetectionService } = await import('../../services/cli-detection.service');
+    return cliDetectionService.detectTool(packageManager);
+  });
+
+  handleIpc('project:install-tool', async (_event, toolName) => {
+    const { cliDetectionService } = await import('../../services/cli-detection.service');
+    return cliDetectionService.installTool(toolName);
+  });
+
+  handleIpc('project:scaffold', async (_event, config) => {
+    const { projectScaffoldService } = await import('../../services/project-scaffold.service');
+    return projectScaffoldService.scaffold(config);
+  });
+
+  handleIpc('project:scaffold-database', async (_event, config) => {
+    const { databaseScaffoldService } = await import('../../services/database-scaffold.service');
+    return databaseScaffoldService.scaffoldDatabase(config);
+  });
+
+  handleIpc('project:get-orm-options', async (_event, ecosystem, engine) => {
+    const { databaseScaffoldService } = await import('../../services/database-scaffold.service');
+    return databaseScaffoldService.getORMOptions(ecosystem, engine);
+  });
+
+  handleIpc('project:create-github-repo', async (_event, name, options) => {
+    const { gitHubRestService } = await import('../../services/github-rest.service');
+    return gitHubRestService.createRepository(name, options);
+  });
+
+  handleIpc('project:initialize-git', async (_event, projectPath, remoteName, remoteUrl) => {
+    const { gitService } = await import('../../services');
+    await gitService.init(projectPath);
+    await gitService.createBranch(projectPath, 'main');
+    await gitService.add(projectPath, ['.']);
+    await gitService.commit(projectPath, 'Initial commit');
+    await gitService.createBranch(projectPath, 'dev');
+    if (remoteUrl) {
+      await gitService.addRemote(projectPath, remoteName || 'origin', remoteUrl);
+      await gitService.push(projectPath, remoteName || 'origin', 'main');
+      await gitService.push(projectPath, remoteName || 'origin', 'dev');
+    }
+  });
+}

--- a/src/main/services/cli-detection.service.ts
+++ b/src/main/services/cli-detection.service.ts
@@ -1,0 +1,178 @@
+/**
+ * CLI Detection Service
+ *
+ * Detects installed CLI tools and their versions for project scaffolding
+ */
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { createLogger } from '../utils/logger';
+import type { Ecosystem, ToolDetectionResult, ToolInstallResult } from '../ipc/channels/types';
+
+const log = createLogger('cli-detection');
+const execFileAsync = promisify(execFile);
+
+const ECOSYSTEM_TOOLS: Record<string, { tools: string[]; required: string[] }> = {
+  node: {
+    tools: ['node', 'npm', 'npx', 'yarn', 'pnpm', 'bun'],
+    required: ['node', 'npm'],
+  },
+  python: {
+    tools: ['python3', 'python', 'pip', 'pip3', 'poetry', 'uv'],
+    required: ['python3', 'pip'],
+  },
+  rust: {
+    tools: ['rustc', 'cargo'],
+    required: ['rustc', 'cargo'],
+  },
+  go: {
+    tools: ['go'],
+    required: ['go'],
+  },
+  ruby: {
+    tools: ['ruby', 'bundler', 'rails', 'gem'],
+    required: ['ruby'],
+  },
+  php: {
+    tools: ['php', 'composer'],
+    required: ['php', 'composer'],
+  },
+  java: {
+    tools: ['java', 'javac', 'mvn', 'gradle'],
+    required: ['java'],
+  },
+};
+
+const MONOREPO_TOOLS: Record<string, string[]> = {
+  turborepo: ['turbo'],
+  nx: ['nx'],
+  'pnpm-workspaces': ['pnpm'],
+  'cargo-workspaces': ['cargo'],
+  'go-workspaces': ['go'],
+  'uv-workspaces': ['uv'],
+};
+
+const TOOL_INSTALL_COMMANDS: Record<string, { cmd: string; args: string[] }> = {
+  bun: { cmd: 'npm', args: ['install', '-g', 'bun'] },
+  pnpm: { cmd: 'npm', args: ['install', '-g', 'pnpm'] },
+  yarn: { cmd: 'npm', args: ['install', '-g', 'yarn'] },
+  uv: { cmd: 'pip', args: ['install', 'uv'] },
+  poetry: { cmd: 'pip', args: ['install', 'poetry'] },
+  turbo: { cmd: 'npm', args: ['install', '-g', 'turbo'] },
+  nx: { cmd: 'npm', args: ['install', '-g', 'nx'] },
+};
+
+function getWhichCommand(): string {
+  return process.platform === 'win32' ? 'where' : 'which';
+}
+
+function execShellSafe(
+  cmd: string,
+  args: string[],
+  opts: { timeout?: number; cwd?: string } = {}
+): ReturnType<typeof execFileAsync> {
+  if (process.platform === 'win32') {
+    const fullCommand = `${cmd} ${args.join(' ')}`;
+    return execFileAsync(fullCommand, [], { ...opts, shell: true });
+  }
+  return execFileAsync(cmd, args, opts);
+}
+
+export async function detectTool(name: string): Promise<ToolDetectionResult> {
+  const whichCmd = getWhichCommand();
+  try {
+    const { stdout } = await execShellSafe(whichCmd, [name], { timeout: 5000 });
+    const toolPath = String(stdout).trim().split('\n')[0];
+
+    let version: string | undefined;
+    try {
+      const { stdout: versionOut } = await execShellSafe(name, ['--version'], { timeout: 5000 });
+      const match = String(versionOut)
+        .trim()
+        .match(/(\d+\.\d+[\d.]*)/);
+      version = match ? match[1] : undefined;
+    } catch {
+      // Version detection is best-effort
+    }
+
+    return { name, installed: true, version, path: toolPath, required: false };
+  } catch {
+    return { name, installed: false, required: false };
+  }
+}
+
+export function getInstallCommand(toolName: string): string | null {
+  const info = TOOL_INSTALL_COMMANDS[toolName];
+  if (!info) return null;
+  return `${info.cmd} ${info.args.join(' ')}`;
+}
+
+export async function installTool(toolName: string): Promise<ToolInstallResult> {
+  const installInfo = TOOL_INSTALL_COMMANDS[toolName];
+  if (!installInfo) {
+    return { success: false, message: `No install command known for '${toolName}'` };
+  }
+
+  log.info(`Installing tool: ${toolName}`, {
+    cmd: `${installInfo.cmd} ${installInfo.args.join(' ')}`,
+  });
+
+  try {
+    await execShellSafe(installInfo.cmd, installInfo.args, { timeout: 120000 });
+
+    const result = await detectTool(toolName);
+    if (result.installed) {
+      log.info(`Tool installed successfully: ${toolName}`, { version: result.version });
+      return {
+        success: true,
+        message: `${toolName} installed successfully`,
+        version: result.version,
+      };
+    }
+
+    return {
+      success: false,
+      message: `Install command ran but ${toolName} was not detected on PATH. You may need to restart the application.`,
+    };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    log.error(`Failed to install ${toolName}:`, msg);
+    return { success: false, message: `Install failed: ${msg}` };
+  }
+}
+
+export async function detectEcosystemTools(
+  ecosystem: Ecosystem,
+  isMonorepo: boolean = false,
+  monorepoTool?: string
+): Promise<ToolDetectionResult[]> {
+  const config = ECOSYSTEM_TOOLS[ecosystem];
+  if (!config) {
+    log.warn(`Unknown ecosystem: ${ecosystem}`);
+    return [];
+  }
+
+  const toolNames = [...config.tools];
+
+  if (isMonorepo && monorepoTool && MONOREPO_TOOLS[monorepoTool]) {
+    for (const t of MONOREPO_TOOLS[monorepoTool]) {
+      if (!toolNames.includes(t)) {
+        toolNames.push(t);
+      }
+    }
+  }
+
+  const results = await Promise.all(toolNames.map((t) => detectTool(t)));
+
+  for (const result of results) {
+    result.required = config.required.includes(result.name);
+  }
+
+  return results;
+}
+
+export const cliDetectionService = {
+  detectTool,
+  detectEcosystemTools,
+  installTool,
+  getInstallCommand,
+};

--- a/src/main/services/database-scaffold.service.ts
+++ b/src/main/services/database-scaffold.service.ts
@@ -1,0 +1,354 @@
+/**
+ * Database Scaffold Service
+ *
+ * Generates ORM configs, Docker Compose, and env vars for new projects
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { createLogger } from '../utils/logger';
+import type { Ecosystem, ORMOption, ScaffoldResult } from '../ipc/channels/types';
+
+const log = createLogger('database-scaffold');
+
+interface DatabaseScaffoldConfig {
+  projectPath: string;
+  projectName: string;
+  ecosystem: Ecosystem;
+  engine: 'postgresql' | 'mysql' | 'mongodb' | 'sqlite' | 'redis' | 'none';
+  orm?: string;
+  includeDocker: boolean;
+  includeEnvVars: boolean;
+  additionalEngines: string[];
+}
+
+const ORM_MAP: Record<string, Record<string, ORMOption[]>> = {
+  node: {
+    postgresql: [
+      { id: 'prisma', name: 'Prisma', recommended: true },
+      { id: 'drizzle', name: 'Drizzle', recommended: false },
+      { id: 'typeorm', name: 'TypeORM', recommended: false },
+      { id: 'knex', name: 'Knex', recommended: false },
+    ],
+    mysql: [
+      { id: 'prisma', name: 'Prisma', recommended: true },
+      { id: 'drizzle', name: 'Drizzle', recommended: false },
+      { id: 'typeorm', name: 'TypeORM', recommended: false },
+      { id: 'knex', name: 'Knex', recommended: false },
+    ],
+    mongodb: [
+      { id: 'mongoose', name: 'Mongoose', recommended: true },
+      { id: 'prisma', name: 'Prisma', recommended: false },
+    ],
+    sqlite: [
+      { id: 'prisma', name: 'Prisma', recommended: true },
+      { id: 'drizzle', name: 'Drizzle', recommended: false },
+      { id: 'better-sqlite3', name: 'better-sqlite3', recommended: false },
+      { id: 'knex', name: 'Knex', recommended: false },
+    ],
+  },
+  python: {
+    postgresql: [
+      { id: 'sqlalchemy', name: 'SQLAlchemy', recommended: true },
+      { id: 'django-orm', name: 'Django ORM', recommended: false },
+      { id: 'tortoise', name: 'Tortoise ORM', recommended: false },
+    ],
+    mysql: [
+      { id: 'sqlalchemy', name: 'SQLAlchemy', recommended: true },
+      { id: 'django-orm', name: 'Django ORM', recommended: false },
+    ],
+    mongodb: [
+      { id: 'motor', name: 'Motor', recommended: true },
+      { id: 'mongoengine', name: 'MongoEngine', recommended: false },
+    ],
+    sqlite: [
+      { id: 'sqlalchemy', name: 'SQLAlchemy', recommended: true },
+      { id: 'django-orm', name: 'Django ORM', recommended: false },
+    ],
+  },
+  rust: {
+    postgresql: [
+      { id: 'diesel', name: 'Diesel', recommended: true },
+      { id: 'sqlx', name: 'SQLx', recommended: false },
+      { id: 'sea-orm', name: 'SeaORM', recommended: false },
+    ],
+    mysql: [
+      { id: 'diesel', name: 'Diesel', recommended: true },
+      { id: 'sqlx', name: 'SQLx', recommended: false },
+    ],
+    mongodb: [{ id: 'mongodb', name: 'mongodb crate', recommended: true }],
+    sqlite: [
+      { id: 'diesel', name: 'Diesel', recommended: true },
+      { id: 'sqlx', name: 'SQLx', recommended: false },
+      { id: 'rusqlite', name: 'rusqlite', recommended: false },
+    ],
+  },
+  go: {
+    postgresql: [
+      { id: 'gorm', name: 'GORM', recommended: true },
+      { id: 'ent', name: 'Ent', recommended: false },
+    ],
+    mysql: [
+      { id: 'gorm', name: 'GORM', recommended: true },
+      { id: 'ent', name: 'Ent', recommended: false },
+    ],
+    mongodb: [{ id: 'mongo-driver', name: 'mongo-driver', recommended: true }],
+    sqlite: [
+      { id: 'gorm', name: 'GORM', recommended: true },
+      { id: 'go-sqlite3', name: 'go-sqlite3', recommended: false },
+    ],
+  },
+  ruby: {
+    postgresql: [
+      { id: 'activerecord', name: 'ActiveRecord', recommended: true },
+      { id: 'sequel', name: 'Sequel', recommended: false },
+    ],
+    mysql: [
+      { id: 'activerecord', name: 'ActiveRecord', recommended: true },
+      { id: 'sequel', name: 'Sequel', recommended: false },
+    ],
+    mongodb: [{ id: 'mongoid', name: 'Mongoid', recommended: true }],
+    sqlite: [{ id: 'activerecord', name: 'ActiveRecord', recommended: true }],
+  },
+  php: {
+    postgresql: [
+      { id: 'eloquent', name: 'Eloquent', recommended: true },
+      { id: 'doctrine', name: 'Doctrine', recommended: false },
+    ],
+    mysql: [
+      { id: 'eloquent', name: 'Eloquent', recommended: true },
+      { id: 'doctrine', name: 'Doctrine', recommended: false },
+    ],
+    mongodb: [{ id: 'laravel-mongodb', name: 'Laravel MongoDB', recommended: true }],
+    sqlite: [{ id: 'eloquent', name: 'Eloquent', recommended: true }],
+  },
+  java: {
+    postgresql: [
+      { id: 'spring-data-jpa', name: 'Spring Data JPA', recommended: true },
+      { id: 'hibernate', name: 'Hibernate', recommended: false },
+    ],
+    mysql: [
+      { id: 'spring-data-jpa', name: 'Spring Data JPA', recommended: true },
+      { id: 'hibernate', name: 'Hibernate', recommended: false },
+    ],
+    mongodb: [{ id: 'spring-data-mongodb', name: 'Spring Data MongoDB', recommended: true }],
+    sqlite: [{ id: 'spring-data-jpa', name: 'Spring Data JPA', recommended: true }],
+  },
+};
+
+const DOCKER_COMPOSE_TEMPLATES: Record<string, string> = {
+  postgresql: `  db:
+    image: postgres:16-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: dev
+      POSTGRES_PASSWORD: dev
+      POSTGRES_DB: \${PROJECT_NAME}
+    volumes:
+      - db_data:/var/lib/postgresql/data`,
+  mysql: `  db:
+    image: mysql:8
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: dev
+      MYSQL_DATABASE: \${PROJECT_NAME}
+      MYSQL_USER: dev
+      MYSQL_PASSWORD: dev
+    volumes:
+      - db_data:/var/lib/mysql`,
+  mongodb: `  db:
+    image: mongo:7
+    ports:
+      - "27017:27017"
+    volumes:
+      - db_data:/data/db`,
+  redis: `  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data`,
+};
+
+const ENV_TEMPLATES: Record<string, string> = {
+  postgresql: 'DATABASE_URL=postgres://dev:dev@localhost:5432/{projectName}',
+  mysql: 'DATABASE_URL=mysql://dev:dev@localhost:3306/{projectName}',
+  mongodb: 'MONGODB_URI=mongodb://localhost:27017/{projectName}',
+  sqlite: 'DATABASE_URL=file:./dev.db',
+  redis: 'REDIS_URL=redis://localhost:6379',
+};
+
+export function getORMOptions(ecosystem: Ecosystem, engine: string): ORMOption[] {
+  return ORM_MAP[ecosystem]?.[engine] || [];
+}
+
+export function getDependencies(ecosystem: Ecosystem, engine: string, orm: string): string[] {
+  const deps: Record<string, Record<string, Record<string, string[]>>> = {
+    node: {
+      postgresql: {
+        prisma: ['prisma', '@prisma/client'],
+        drizzle: ['drizzle-orm', 'drizzle-kit', 'pg'],
+        typeorm: ['typeorm', 'pg', 'reflect-metadata'],
+        knex: ['knex', 'pg'],
+      },
+      mysql: {
+        prisma: ['prisma', '@prisma/client'],
+        drizzle: ['drizzle-orm', 'drizzle-kit', 'mysql2'],
+        typeorm: ['typeorm', 'mysql2', 'reflect-metadata'],
+        knex: ['knex', 'mysql2'],
+      },
+      mongodb: {
+        mongoose: ['mongoose'],
+        prisma: ['prisma', '@prisma/client'],
+      },
+      sqlite: {
+        prisma: ['prisma', '@prisma/client'],
+        drizzle: ['drizzle-orm', 'drizzle-kit', 'better-sqlite3'],
+        'better-sqlite3': ['better-sqlite3', '@types/better-sqlite3'],
+        knex: ['knex', 'better-sqlite3'],
+      },
+    },
+  };
+
+  return deps[ecosystem]?.[engine]?.[orm] || [];
+}
+
+function generateDockerCompose(config: DatabaseScaffoldConfig): string {
+  const services: string[] = [];
+  const volumes: string[] = [];
+
+  const primary = DOCKER_COMPOSE_TEMPLATES[config.engine];
+  if (primary) {
+    services.push(primary.replace(/\$\{PROJECT_NAME\}/g, config.projectName));
+    volumes.push(config.engine === 'redis' ? 'redis_data:' : 'db_data:');
+  }
+
+  for (const extra of config.additionalEngines) {
+    const tmpl = DOCKER_COMPOSE_TEMPLATES[extra];
+    if (tmpl) {
+      services.push(tmpl.replace(/\$\{PROJECT_NAME\}/g, config.projectName));
+      if (extra === 'redis' && !volumes.includes('redis_data:')) {
+        volumes.push('redis_data:');
+      } else if (extra !== 'redis' && !volumes.includes('db_data:')) {
+        volumes.push('db_data:');
+      }
+    }
+  }
+
+  return `version: "3.8"\n\nservices:\n${services.join('\n\n')}\n\nvolumes:\n${volumes.map((v) => `  ${v}`).join('\n')}\n`;
+}
+
+function generateEnvVars(config: DatabaseScaffoldConfig): string {
+  const lines: string[] = [];
+
+  const primary = ENV_TEMPLATES[config.engine];
+  if (primary) {
+    lines.push(primary.replace(/{projectName}/g, config.projectName));
+  }
+
+  for (const extra of config.additionalEngines) {
+    const tmpl = ENV_TEMPLATES[extra];
+    if (tmpl) {
+      lines.push(tmpl.replace(/{projectName}/g, config.projectName));
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function generatePrismaSchema(engine: string, _projectName: string): string {
+  const providerMap: Record<string, string> = {
+    postgresql: 'postgresql',
+    mysql: 'mysql',
+    mongodb: 'mongodb',
+    sqlite: 'sqlite',
+  };
+  const provider = providerMap[engine] || 'postgresql';
+
+  return `// Prisma Schema \u2014 generated by Cola Records
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "${provider}"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  name      String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+`;
+}
+
+export async function scaffoldDatabase(config: DatabaseScaffoldConfig): Promise<ScaffoldResult> {
+  const filesCreated: string[] = [];
+  const warnings: string[] = [];
+
+  if (config.engine === 'none') {
+    return { success: true, message: 'No database selected', filesCreated, warnings };
+  }
+
+  try {
+    if (config.includeDocker) {
+      const composePath = path.join(config.projectPath, 'docker-compose.yml');
+      const content = generateDockerCompose(config);
+      fs.writeFileSync(composePath, content, 'utf-8');
+      filesCreated.push('docker-compose.yml');
+      log.info(`Generated docker-compose.yml for ${config.engine}`);
+    }
+
+    if (config.includeEnvVars) {
+      const envPath = path.join(config.projectPath, '.env');
+      const envContent = generateEnvVars(config);
+      if (fs.existsSync(envPath)) {
+        fs.appendFileSync(envPath, '\n\n# Database\n' + envContent + '\n', 'utf-8');
+      } else {
+        fs.writeFileSync(envPath, '# Database\n' + envContent + '\n', 'utf-8');
+        filesCreated.push('.env');
+      }
+      log.info('Generated database environment variables');
+    }
+
+    if (config.orm && config.ecosystem === 'node' && config.orm === 'prisma') {
+      const prismaDir = path.join(config.projectPath, 'prisma');
+      if (!fs.existsSync(prismaDir)) {
+        fs.mkdirSync(prismaDir, { recursive: true });
+      }
+      fs.writeFileSync(
+        path.join(prismaDir, 'schema.prisma'),
+        generatePrismaSchema(config.engine, config.projectName),
+        'utf-8'
+      );
+      filesCreated.push('prisma/schema.prisma');
+      log.info('Generated Prisma schema');
+    }
+
+    return {
+      success: true,
+      message: `Database scaffolding complete for ${config.engine}${config.orm ? ` with ${config.orm}` : ''}`,
+      filesCreated,
+      warnings,
+    };
+  } catch (error) {
+    log.error('Database scaffolding failed:', error);
+    return {
+      success: false,
+      message: `Database scaffolding failed: ${error}`,
+      filesCreated,
+      warnings,
+    };
+  }
+}
+
+export const databaseScaffoldService = {
+  scaffoldDatabase,
+  getORMOptions,
+  getDependencies,
+};

--- a/src/main/services/github/github-extras.service.ts
+++ b/src/main/services/github/github-extras.service.ts
@@ -224,6 +224,38 @@ export async function unstarRepository(
   }
 }
 
+export async function createRepository(
+  client: Octokit,
+  name: string,
+  options: {
+    description?: string;
+    isPrivate?: boolean;
+    autoInit?: boolean;
+  }
+): Promise<GitHubRepository> {
+  try {
+    const response = await client.repos.createForAuthenticatedUser({
+      name,
+      description: options.description || '',
+      private: options.isPrivate ?? false,
+      auto_init: options.autoInit ?? false,
+    });
+
+    return {
+      id: response.data.id.toString(),
+      name: response.data.name,
+      fullName: response.data.full_name,
+      description: response.data.description || '',
+      url: response.data.clone_url || response.data.html_url,
+      language: response.data.language || 'Unknown',
+      stars: response.data.stargazers_count,
+      forks: response.data.forks_count,
+    };
+  } catch (error) {
+    throw new Error(`Failed to create repository ${name}: ${error}`);
+  }
+}
+
 export async function getRateLimit(client: Octokit) {
   try {
     const response = await client.rateLimit.get();

--- a/src/main/services/github/index.ts
+++ b/src/main/services/github/index.ts
@@ -258,6 +258,17 @@ export class GitHubRestService extends GitHubRestServiceBase {
     return extras.unstarRepository(this.getClient(), owner, repo);
   }
 
+  async createRepository(
+    name: string,
+    options: {
+      description?: string;
+      isPrivate?: boolean;
+      autoInit?: boolean;
+    }
+  ): Promise<GitHubRepository> {
+    return extras.createRepository(this.getClient(), name, options);
+  }
+
   async getRateLimit() {
     return extras.getRateLimit(this.getClient());
   }

--- a/src/main/services/project-scaffold.service.ts
+++ b/src/main/services/project-scaffold.service.ts
@@ -1,0 +1,425 @@
+/**
+ * Project Scaffold Service
+ *
+ * Orchestrates project creation using CLI tools and template files
+ */
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import * as fs from 'fs';
+import * as path from 'path';
+import { createLogger } from '../utils/logger';
+import type { Ecosystem, ScaffoldConfig, ScaffoldResult } from '../ipc/channels/types';
+import { getGitignoreTemplate } from './templates/gitignore.templates';
+import { getLicenseTemplate } from './templates/license.templates';
+
+const log = createLogger('project-scaffold');
+const execFileAsync = promisify(execFile);
+
+interface ScaffoldCommand {
+  cmd: string;
+  args: string[];
+  cwd?: string;
+}
+
+function getScaffoldCommand(config: ScaffoldConfig): ScaffoldCommand | null {
+  const {
+    ecosystem,
+    framework,
+    projectName,
+    projectPath,
+    packageManager,
+    isMonorepo,
+    monorepoTool,
+  } = config;
+  const parentDir = path.dirname(projectPath);
+
+  if (isMonorepo) {
+    return getMonorepoCommand(ecosystem, monorepoTool, projectName, parentDir, packageManager);
+  }
+
+  switch (ecosystem) {
+    case 'node':
+      return getNodeCommand(framework, projectName, parentDir, packageManager);
+    case 'python':
+      return getPythonCommand(framework, projectName, parentDir, packageManager);
+    case 'rust':
+      return { cmd: 'cargo', args: ['init', projectPath], cwd: parentDir };
+    case 'go':
+      return null; // handled specially — mkdir + go mod init
+    case 'ruby':
+      return getRubyCommand(framework, projectName, parentDir);
+    case 'php':
+      return getPHPCommand(framework, projectName, parentDir);
+    case 'java':
+      return getJavaCommand(framework, projectName, parentDir);
+    default:
+      return null;
+  }
+}
+
+function getNodeCommand(
+  framework: string | undefined,
+  name: string,
+  cwd: string,
+  pm?: string
+): ScaffoldCommand | null {
+  const runner = pm || 'npm';
+  const template =
+    framework === 'react' ? 'react-ts' : framework === 'vanilla-ts' ? 'vanilla-ts' : 'vanilla';
+
+  switch (framework) {
+    case 'react':
+    case 'vanilla-ts':
+    case 'vanilla':
+      if (runner === 'bun') {
+        return { cmd: 'bun', args: ['create', 'vite', name, '--template', template], cwd };
+      }
+      if (runner === 'pnpm') {
+        return { cmd: 'pnpm', args: ['create', 'vite', name, '--template', template], cwd };
+      }
+      if (runner === 'yarn') {
+        return { cmd: 'yarn', args: ['create', 'vite', name, '--template', template], cwd };
+      }
+      return {
+        cmd: 'npm',
+        args: ['create', 'vite@latest', name, '--', '--template', template],
+        cwd,
+      };
+    case 'nextjs':
+      if (runner === 'bun') {
+        return { cmd: 'bun', args: ['create', 'next-app', name, '--ts', '--yes'], cwd };
+      }
+      if (runner === 'pnpm') {
+        return { cmd: 'pnpm', args: ['create', 'next-app', name, '--ts', '--yes'], cwd };
+      }
+      return {
+        cmd: 'npx',
+        args: ['create-next-app@latest', name, '--ts', '--use-npm', '--yes'],
+        cwd,
+      };
+    case 'express':
+      return null; // mkdir + npm init + install express
+    default:
+      return { cmd: runner, args: ['init', '-y'], cwd: path.join(cwd, name) };
+  }
+}
+
+function getPythonCommand(
+  _framework: string | undefined,
+  name: string,
+  cwd: string,
+  pm?: string
+): ScaffoldCommand | null {
+  if (pm === 'uv') {
+    return { cmd: 'uv', args: ['init', name], cwd };
+  }
+  if (pm === 'poetry') {
+    return { cmd: 'poetry', args: ['new', name], cwd };
+  }
+  return null; // mkdir + manual structure
+}
+
+function getRubyCommand(
+  framework: string | undefined,
+  name: string,
+  cwd: string
+): ScaffoldCommand | null {
+  if (framework === 'rails') {
+    return { cmd: 'rails', args: ['new', name, '--skip-git'], cwd };
+  }
+  return { cmd: 'bundler', args: ['gem', name], cwd };
+}
+
+function getPHPCommand(
+  framework: string | undefined,
+  name: string,
+  cwd: string
+): ScaffoldCommand | null {
+  if (framework === 'laravel') {
+    return { cmd: 'composer', args: ['create-project', 'laravel/laravel', name], cwd };
+  }
+  return null;
+}
+
+function getJavaCommand(
+  framework: string | undefined,
+  _name: string,
+  _cwd: string
+): ScaffoldCommand | null {
+  if (framework === 'spring-boot') {
+    return null; // Spring Initializr requires web API or manual setup
+  }
+  return null; // mkdir + manual structure
+}
+
+function getMonorepoCommand(
+  _ecosystem: Ecosystem,
+  tool: string | undefined,
+  name: string,
+  cwd: string,
+  pm?: string
+): ScaffoldCommand | null {
+  switch (tool) {
+    case 'turborepo':
+      return {
+        cmd: 'npx',
+        args: [
+          'create-turbo@latest',
+          name,
+          '--example',
+          'basic',
+          '--package-manager',
+          pm || 'npm',
+          '--skip-install',
+        ],
+        cwd,
+      };
+    case 'nx':
+      return {
+        cmd: 'npx',
+        args: [
+          'create-nx-workspace@latest',
+          name,
+          '--preset=ts',
+          '--nxCloud=skip',
+          '--interactive=false',
+          '--packageManager',
+          pm || 'npm',
+          '--skipGit',
+        ],
+        cwd,
+      };
+    case 'pnpm-workspaces':
+      return null; // manual setup with pnpm-workspace.yaml
+    case 'cargo-workspaces':
+      return null; // manual Cargo.toml with [workspace]
+    case 'go-workspaces':
+      return null; // go work init
+    case 'uv-workspaces':
+      return { cmd: 'uv', args: ['init', '--workspace', name], cwd };
+    default:
+      return null;
+  }
+}
+
+async function runCommand(
+  cmd: ScaffoldCommand,
+  timeout: number = 120000
+): Promise<{ stdout: string; stderr: string }> {
+  const env = { ...process.env, npm_config_yes: 'true' };
+  try {
+    if (process.platform === 'win32') {
+      const fullCommand = `${cmd.cmd} ${cmd.args.join(' ')}`;
+      return await execFileAsync(fullCommand, [], { cwd: cmd.cwd, timeout, shell: true, env });
+    }
+    return await execFileAsync(cmd.cmd, cmd.args, { cwd: cmd.cwd, timeout, env });
+  } catch (error) {
+    throw new Error(`Command '${cmd.cmd} ${cmd.args.join(' ')}' failed: ${error}`);
+  }
+}
+
+async function createDirectoryStructure(config: ScaffoldConfig): Promise<void> {
+  if (!fs.existsSync(config.projectPath)) {
+    fs.mkdirSync(config.projectPath, { recursive: true });
+  }
+}
+
+async function scaffoldGo(config: ScaffoldConfig): Promise<string[]> {
+  const files: string[] = [];
+  const moduleName = `github.com/user/${config.projectName}`;
+
+  await runCommand({ cmd: 'go', args: ['mod', 'init', moduleName], cwd: config.projectPath });
+  files.push('go.mod');
+
+  const mainGo = `package main
+
+import "fmt"
+
+func main() {
+\tfmt.Println("Hello, ${config.projectName}!")
+}
+`;
+  fs.writeFileSync(path.join(config.projectPath, 'main.go'), mainGo, 'utf-8');
+  files.push('main.go');
+
+  return files;
+}
+
+async function scaffoldMonorepoManual(config: ScaffoldConfig): Promise<string[]> {
+  const files: string[] = [];
+
+  switch (config.monorepoTool) {
+    case 'pnpm-workspaces': {
+      const workspaceYaml = `packages:\n  - "packages/*"\n`;
+      fs.writeFileSync(
+        path.join(config.projectPath, 'pnpm-workspace.yaml'),
+        workspaceYaml,
+        'utf-8'
+      );
+      files.push('pnpm-workspace.yaml');
+
+      const pkgJson = JSON.stringify({ name: config.projectName, private: true }, null, 2);
+      fs.writeFileSync(path.join(config.projectPath, 'package.json'), pkgJson, 'utf-8');
+      files.push('package.json');
+
+      fs.mkdirSync(path.join(config.projectPath, 'packages'), { recursive: true });
+      break;
+    }
+    case 'cargo-workspaces': {
+      const cargoToml = `[workspace]\nmembers = ["crates/*"]\nresolver = "2"\n\n[workspace.package]\nedition = "2021"\n`;
+      fs.writeFileSync(path.join(config.projectPath, 'Cargo.toml'), cargoToml, 'utf-8');
+      files.push('Cargo.toml');
+
+      fs.mkdirSync(path.join(config.projectPath, 'crates'), { recursive: true });
+      break;
+    }
+    case 'go-workspaces': {
+      await runCommand({ cmd: 'go', args: ['work', 'init'], cwd: config.projectPath });
+      files.push('go.work');
+
+      fs.mkdirSync(path.join(config.projectPath, 'packages'), { recursive: true });
+      break;
+    }
+  }
+
+  return files;
+}
+
+function writeExtras(config: ScaffoldConfig): string[] {
+  const files: string[] = [];
+
+  if (config.extras.gitignore) {
+    const content = getGitignoreTemplate(config.ecosystem);
+    fs.writeFileSync(path.join(config.projectPath, '.gitignore'), content, 'utf-8');
+    files.push('.gitignore');
+  }
+
+  if (config.extras.editorconfig) {
+    const content = `root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{py,rs,go,java,rb,php}]
+indent_size = 4
+`;
+    fs.writeFileSync(path.join(config.projectPath, '.editorconfig'), content, 'utf-8');
+    files.push('.editorconfig');
+  }
+
+  if (config.extras.envFile) {
+    const envPath = path.join(config.projectPath, '.env');
+    if (!fs.existsSync(envPath)) {
+      fs.writeFileSync(envPath, '# Environment Variables\n', 'utf-8');
+      files.push('.env');
+    }
+  }
+
+  if (config.extras.readme) {
+    const content = `# ${config.projectName}\n\nA new ${config.ecosystem} project.\n`;
+    fs.writeFileSync(path.join(config.projectPath, 'README.md'), content, 'utf-8');
+    files.push('README.md');
+  }
+
+  if (config.extras.license) {
+    const licenseContent = getLicenseTemplate(
+      config.extras.license,
+      'Your Name',
+      new Date().getFullYear()
+    );
+    if (licenseContent) {
+      fs.writeFileSync(path.join(config.projectPath, 'LICENSE'), licenseContent, 'utf-8');
+      files.push('LICENSE');
+    }
+  }
+
+  return files;
+}
+
+export async function scaffold(config: ScaffoldConfig): Promise<ScaffoldResult> {
+  const filesCreated: string[] = [];
+  const warnings: string[] = [];
+
+  try {
+    log.info(`Scaffolding ${config.ecosystem} project: ${config.projectName}`);
+
+    // Run scaffold command
+    const cmd = getScaffoldCommand(config);
+
+    if (config.ecosystem === 'go' && !config.isMonorepo) {
+      await createDirectoryStructure(config);
+      const goFiles = await scaffoldGo(config);
+      filesCreated.push(...goFiles);
+    } else if (config.isMonorepo && !cmd) {
+      await createDirectoryStructure(config);
+      const monoFiles = await scaffoldMonorepoManual(config);
+      filesCreated.push(...monoFiles);
+    } else if (cmd) {
+      // CLI scaffold tools (create-nx-workspace, create-turbo, create-vite, etc.)
+      // create the directory themselves — do NOT pre-create it
+      try {
+        await runCommand(cmd);
+        filesCreated.push('(scaffold output)');
+      } catch (error) {
+        // Ensure directory exists for extras even if scaffold failed
+        await createDirectoryStructure(config);
+        warnings.push(`Scaffold command failed: ${error}. Created directory only.`);
+        log.warn(`Scaffold command failed for ${config.projectName}:`, error);
+      }
+    } else {
+      // No scaffold command — create basic structure manually
+      await createDirectoryStructure(config);
+      if (config.ecosystem === 'node') {
+        const pkgJson = JSON.stringify(
+          {
+            name: config.projectName,
+            version: '0.1.0',
+            private: true,
+            scripts: { test: 'echo "Error: no test specified" && exit 1' },
+          },
+          null,
+          2
+        );
+        fs.writeFileSync(path.join(config.projectPath, 'package.json'), pkgJson, 'utf-8');
+        filesCreated.push('package.json');
+      } else if (config.ecosystem === 'python') {
+        fs.mkdirSync(path.join(config.projectPath, 'src'), { recursive: true });
+        fs.writeFileSync(path.join(config.projectPath, 'src', '__init__.py'), '', 'utf-8');
+        filesCreated.push('src/__init__.py');
+      }
+    }
+
+    // Write extras
+    const extraFiles = writeExtras(config);
+    filesCreated.push(...extraFiles);
+
+    log.info(`Scaffold complete: ${filesCreated.length} files created`);
+
+    return {
+      success: true,
+      message: `Project ${config.projectName} scaffolded successfully`,
+      filesCreated,
+      warnings,
+    };
+  } catch (error) {
+    log.error('Scaffold failed:', error);
+    return {
+      success: false,
+      message: `Scaffold failed: ${error}`,
+      filesCreated,
+      warnings,
+    };
+  }
+}
+
+export const projectScaffoldService = {
+  scaffold,
+};

--- a/src/main/services/templates/gitignore.templates.ts
+++ b/src/main/services/templates/gitignore.templates.ts
@@ -1,0 +1,225 @@
+/**
+ * Gitignore Templates
+ *
+ * Per-ecosystem .gitignore content for new projects
+ */
+import type { Ecosystem } from '../../ipc/channels/types';
+
+const TEMPLATES: Record<string, string> = {
+  node: `# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Build
+dist/
+build/
+.next/
+out/
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Testing
+coverage/
+
+# Misc
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+`,
+  python: `# Byte-compiled
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+
+# Distribution
+dist/
+build/
+*.egg-info/
+*.egg
+
+# Environment
+.env
+.env.local
+
+# IDE
+.vscode/
+.idea/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Testing
+.coverage
+htmlcov/
+.pytest_cache/
+.mypy_cache/
+`,
+  rust: `# Build
+/target/
+
+# Environment
+.env
+
+# IDE
+.vscode/
+.idea/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+`,
+  go: `# Binary
+/bin/
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary
+*.test
+
+# Coverage
+*.out
+coverage.txt
+
+# Vendor
+vendor/
+
+# Environment
+.env
+
+# IDE
+.vscode/
+.idea/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+`,
+  ruby: `# Bundler
+/.bundle/
+/vendor/bundle/
+
+# Gems
+*.gem
+.gem/
+
+# Environment
+.env
+
+# IDE
+.vscode/
+.idea/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Testing
+/coverage/
+/spec/reports/
+
+# Logs
+/log/
+/tmp/
+`,
+  php: `# Dependencies
+/vendor/
+
+# Environment
+.env
+
+# IDE
+.vscode/
+.idea/
+*.swp
+.phpunit.result.cache
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Cache
+/bootstrap/cache/
+/storage/
+
+# Build
+/public/hot
+/public/storage
+`,
+  java: `# Build
+/target/
+/build/
+*.class
+*.jar
+*.war
+*.ear
+
+# IDE
+.vscode/
+.idea/
+*.iml
+.classpath
+.project
+.settings/
+
+# Environment
+.env
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Gradle
+.gradle/
+/build/
+
+# Maven
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+`,
+};
+
+const DEFAULT_TEMPLATE = `# Environment
+.env
+
+# IDE
+.vscode/
+.idea/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+`;
+
+export function getGitignoreTemplate(ecosystem: Ecosystem): string {
+  return TEMPLATES[ecosystem] || DEFAULT_TEMPLATE;
+}

--- a/src/main/services/templates/license.templates.ts
+++ b/src/main/services/templates/license.templates.ts
@@ -1,0 +1,137 @@
+/**
+ * License Templates
+ *
+ * Common open-source license texts for new projects
+ */
+
+const TEMPLATES: Record<string, (fullName: string, year: number) => string> = {
+  MIT: (fullName, year) => `MIT License
+
+Copyright (c) ${year} ${fullName}
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+`,
+  'Apache-2.0': (fullName, year) => `                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+Copyright ${year} ${fullName}
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+`,
+  'GPL-3.0': (fullName, year) => `Copyright (C) ${year} ${fullName}
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+`,
+  'BSD-2-Clause': (fullName, year) => `BSD 2-Clause License
+
+Copyright (c) ${year}, ${fullName}
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+`,
+  ISC: (fullName, year) => `ISC License
+
+Copyright (c) ${year} ${fullName}
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+`,
+  Unlicense: () => `This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>
+`,
+};
+
+export function getLicenseTemplate(license: string, fullName: string, year: number): string {
+  const template = TEMPLATES[license];
+  if (!template) {
+    return '';
+  }
+  return template(fullName, year);
+}

--- a/src/renderer/components/projects/NewProjectWizard.tsx
+++ b/src/renderer/components/projects/NewProjectWizard.tsx
@@ -1,0 +1,413 @@
+import * as React from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '../ui/Dialog';
+import { Button } from '../ui/Button';
+import { Progress } from '../ui/Progress';
+import { useProjectCreation } from '../../hooks/useProjectCreation';
+import { ipc } from '../../ipc/client';
+import type {
+  WizardConfig,
+  Contribution,
+  ORMOption,
+  GitHubConfigTemplate,
+  Ecosystem,
+} from '../../../main/ipc/channels';
+import { WizardStepBasics } from './WizardStepBasics';
+import { WizardStepEcosystem, PACKAGE_MANAGERS } from './WizardStepEcosystem';
+import type { ToolValidationState } from './WizardStepEcosystem';
+import { WizardStepOptions } from './WizardStepOptions';
+import { WizardStepDatabase } from './WizardStepDatabase';
+import { WizardStepGitHubConfig } from './WizardStepGitHubConfig';
+import { WizardStepReview } from './WizardStepReview';
+
+interface NewProjectWizardProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onComplete: (contribution: Contribution) => void;
+  defaultCategory: 'personal' | 'professional';
+  defaultLocation: string;
+}
+
+const STEP_LABELS = ['Basics', 'Ecosystem', 'Options', 'Database', 'GitHub Config', 'Review'];
+
+const GITHUB_CONFIG_FEATURE_IDS = [
+  'workflows',
+  'dependabot',
+  'release-notes',
+  'issue-templates',
+  'pr-template',
+  'labeler',
+  'codeowners',
+  'auto-assign',
+  'copilot-instructions',
+  'funding',
+  'security',
+  'stale',
+] as const;
+
+/** PMs that ship with their ecosystem runtime and don't need validation */
+const BASE_PMS = new Set(['npm', 'pip', 'cargo', 'go', 'bundler', 'composer', 'maven']);
+
+const DEFAULT_VALIDATION: ToolValidationState = {
+  status: 'idle',
+  toolName: '',
+  alternatives: [],
+};
+
+function createDefaultConfig(
+  defaultCategory: 'personal' | 'professional',
+  defaultLocation: string
+): WizardConfig {
+  return {
+    projectName: '',
+    category: defaultCategory,
+    location: defaultLocation,
+    projectType: 'single',
+    ecosystem: 'node' as Ecosystem,
+    packageManager: 'npm',
+    createGitHubRepo: false,
+    repoVisibility: 'private',
+    repoDescription: '',
+    extras: {
+      gitignore: true,
+      editorconfig: true,
+      readme: true,
+      envFile: false,
+      hooks: false,
+      license: null,
+    },
+    database: {
+      engine: 'none',
+      includeDocker: false,
+      includeEnvVars: false,
+      additionalEngines: [],
+    },
+    githubConfigSelections: [],
+  };
+}
+
+export const NewProjectWizard: React.FC<NewProjectWizardProps> = ({
+  isOpen,
+  onClose,
+  onComplete,
+  defaultCategory,
+  defaultLocation,
+}) => {
+  const [currentStep, setCurrentStep] = React.useState(0);
+  const [config, setConfig] = React.useState<WizardConfig>(() =>
+    createDefaultConfig(defaultCategory, defaultLocation)
+  );
+  const [ormOptions, setOrmOptions] = React.useState<ORMOption[]>([]);
+  const [githubTemplates, setGithubTemplates] = React.useState<
+    Record<string, GitHubConfigTemplate[]>
+  >({});
+  const [templatesLoading, setTemplatesLoading] = React.useState(false);
+  const [toolValidation, setToolValidation] =
+    React.useState<ToolValidationState>(DEFAULT_VALIDATION);
+
+  const { state: creationState, startCreation, reset: resetCreation } = useProjectCreation();
+  const createdContributionRef = React.useRef<Contribution | null>(null);
+
+  const handleConfigChange = (updates: Partial<WizardConfig>) => {
+    setConfig((prev) => ({ ...prev, ...updates }));
+  };
+
+  // Load ORM options when entering step 3 (Database)
+  React.useEffect(() => {
+    if (currentStep === 3) {
+      ipc
+        .invoke('project:get-orm-options', config.ecosystem, config.database.engine)
+        .then((options) => setOrmOptions(options))
+        .catch(() => setOrmOptions([]));
+    }
+  }, [currentStep, config.ecosystem, config.database.engine]);
+
+  // Load GitHub config templates when entering step 4 (GitHub Config)
+  React.useEffect(() => {
+    if (currentStep === 4 && Object.keys(githubTemplates).length === 0) {
+      setTemplatesLoading(true);
+
+      Promise.all(
+        GITHUB_CONFIG_FEATURE_IDS.map(async (featureId) => {
+          const templates = await ipc.invoke('github-config:list-templates', featureId);
+          return { featureId, templates };
+        })
+      )
+        .then((results) => {
+          const templateMap: Record<string, GitHubConfigTemplate[]> = {};
+          for (const { featureId, templates } of results) {
+            templateMap[featureId] = templates;
+          }
+          setGithubTemplates(templateMap);
+        })
+        .catch(() => {
+          // Keep empty templates on failure
+        })
+        .finally(() => {
+          setTemplatesLoading(false);
+        });
+    }
+  }, [currentStep, githubTemplates]);
+
+  const isStepValid = (step: number): boolean => {
+    switch (step) {
+      case 0:
+        return config.projectName.trim().length > 0;
+      case 1:
+        return !!config.ecosystem;
+      default:
+        return true;
+    }
+  };
+
+  const handleNext = async () => {
+    if (currentStep >= STEP_LABELS.length - 1 || !isStepValid(currentStep)) return;
+
+    // When leaving Ecosystem step (1), validate the selected PM
+    if (currentStep === 1 && !BASE_PMS.has(config.packageManager)) {
+      setToolValidation({
+        status: 'checking',
+        toolName: config.packageManager,
+        alternatives: [],
+      });
+
+      try {
+        const result = await ipc.invoke(
+          'project:validate-package-manager',
+          config.ecosystem,
+          config.packageManager
+        );
+
+        if (!result.installed) {
+          const allPms = PACKAGE_MANAGERS[config.ecosystem] ?? [];
+          const alternatives = allPms.filter(
+            (pm) => pm.value !== config.packageManager && BASE_PMS.has(pm.value)
+          );
+
+          setToolValidation({
+            status: 'missing',
+            toolName: config.packageManager,
+            alternatives,
+          });
+          return; // Block step transition
+        }
+      } catch {
+        // Detection failed — don't block on detection errors
+      }
+
+      setToolValidation(DEFAULT_VALIDATION);
+    }
+
+    setToolValidation(DEFAULT_VALIDATION);
+    setCurrentStep((prev) => prev + 1);
+  };
+
+  const handleInstallTool = async () => {
+    const toolName = toolValidation.toolName;
+    setToolValidation((prev) => ({ ...prev, status: 'installing' }));
+
+    try {
+      const result = await ipc.invoke('project:install-tool', toolName);
+      if (result.success) {
+        setToolValidation((prev) => ({
+          ...prev,
+          status: 'installed',
+          installedVersion: result.version,
+        }));
+        // Auto-advance after showing success
+        setTimeout(() => {
+          setToolValidation(DEFAULT_VALIDATION);
+          setCurrentStep((prev) => prev + 1);
+        }, 1500);
+      } else {
+        const allPms = PACKAGE_MANAGERS[config.ecosystem] ?? [];
+        const alternatives = allPms.filter((pm) => pm.value !== toolName && BASE_PMS.has(pm.value));
+        setToolValidation((prev) => ({
+          ...prev,
+          status: 'error',
+          errorMessage: result.message,
+          alternatives,
+        }));
+      }
+    } catch (error) {
+      const allPms = PACKAGE_MANAGERS[config.ecosystem] ?? [];
+      const alternatives = allPms.filter((pm) => pm.value !== toolName && BASE_PMS.has(pm.value));
+      setToolValidation((prev) => ({
+        ...prev,
+        status: 'error',
+        errorMessage: error instanceof Error ? error.message : String(error),
+        alternatives,
+      }));
+    }
+  };
+
+  const handleDismissValidation = () => {
+    setToolValidation(DEFAULT_VALIDATION);
+    setCurrentStep((prev) => prev + 1);
+  };
+
+  const handleBack = () => {
+    if (currentStep > 0) {
+      setToolValidation(DEFAULT_VALIDATION);
+      setCurrentStep((prev) => prev - 1);
+    }
+  };
+
+  const handleCreate = async () => {
+    try {
+      const contribution = await startCreation(config);
+      createdContributionRef.current = contribution;
+    } catch {
+      // Error is tracked in creationState
+    }
+  };
+
+  const handleOpenProject = () => {
+    if (createdContributionRef.current) {
+      onComplete(createdContributionRef.current);
+    }
+    handleClose();
+  };
+
+  const handleClose = () => {
+    setConfig(createDefaultConfig(defaultCategory, defaultLocation));
+    setCurrentStep(0);
+    resetCreation();
+    setOrmOptions([]);
+    setGithubTemplates({});
+    setTemplatesLoading(false);
+    setToolValidation(DEFAULT_VALIDATION);
+    createdContributionRef.current = null;
+    onClose();
+  };
+
+  const renderStepContent = () => {
+    switch (currentStep) {
+      case 0:
+        return <WizardStepBasics config={config} onChange={handleConfigChange} />;
+      case 1:
+        return (
+          <WizardStepEcosystem
+            config={config}
+            onChange={handleConfigChange}
+            toolValidation={toolValidation}
+            onInstallTool={handleInstallTool}
+            onDismissValidation={handleDismissValidation}
+          />
+        );
+      case 2:
+        return <WizardStepOptions config={config} onChange={handleConfigChange} />;
+      case 3:
+        return (
+          <WizardStepDatabase
+            config={config}
+            onChange={handleConfigChange}
+            ormOptions={ormOptions}
+          />
+        );
+      case 4:
+        return (
+          <WizardStepGitHubConfig
+            config={config}
+            onChange={handleConfigChange}
+            templates={githubTemplates}
+            loading={templatesLoading}
+          />
+        );
+      case 5:
+        return (
+          <WizardStepReview
+            config={config}
+            onChange={handleConfigChange}
+            creationState={creationState}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  const isCreating =
+    creationState.status !== 'idle' &&
+    creationState.status !== 'complete' &&
+    creationState.status !== 'error';
+
+  const isComplete = creationState.status === 'complete';
+
+  const isNextDisabled =
+    !isStepValid(currentStep) ||
+    toolValidation.status === 'checking' ||
+    toolValidation.status === 'installing';
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>New Project</DialogTitle>
+        </DialogHeader>
+
+        {/* Step indicator */}
+        <div className="flex items-center gap-1 py-2">
+          {STEP_LABELS.map((label, index) => (
+            <React.Fragment key={label}>
+              {index > 0 && (
+                <div
+                  className={`flex-1 h-px ${index <= currentStep ? 'bg-primary' : 'bg-border'}`}
+                />
+              )}
+              <div className="flex flex-col items-center gap-1">
+                <div
+                  className={`w-2.5 h-2.5 rounded-full transition-colors ${
+                    index === currentStep
+                      ? 'bg-primary ring-2 ring-primary/30'
+                      : index < currentStep
+                        ? 'bg-primary'
+                        : 'bg-muted-foreground/30'
+                  }`}
+                />
+                <span
+                  className={`text-[10px] leading-none whitespace-nowrap ${
+                    index === currentStep ? 'text-primary font-medium' : 'text-muted-foreground'
+                  }`}
+                >
+                  {label}
+                </span>
+              </div>
+            </React.Fragment>
+          ))}
+        </div>
+
+        {/* Progress bar during creation */}
+        {isCreating && <Progress value={creationState.progress} className="h-1.5" />}
+
+        {/* Step content area with scroll */}
+        <div className="min-h-[320px] max-h-[420px] overflow-y-auto styled-scroll py-2">
+          {renderStepContent()}
+        </div>
+
+        {/* Footer navigation */}
+        <DialogFooter className="gap-2 sm:gap-0">
+          {!isCreating && !isComplete && (
+            <>
+              {currentStep > 0 && (
+                <Button variant="outline" onClick={handleBack}>
+                  Back
+                </Button>
+              )}
+              {currentStep < STEP_LABELS.length - 1 && (
+                <Button onClick={handleNext} disabled={isNextDisabled}>
+                  Next
+                </Button>
+              )}
+              {currentStep === STEP_LABELS.length - 1 && (
+                <Button onClick={handleCreate} disabled={!isStepValid(currentStep)}>
+                  Create Project
+                </Button>
+              )}
+            </>
+          )}
+          {isComplete && <Button onClick={handleOpenProject}>Open Project</Button>}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/renderer/components/projects/WizardStepBasics.tsx
+++ b/src/renderer/components/projects/WizardStepBasics.tsx
@@ -1,0 +1,163 @@
+/**
+ * WizardStepBasics
+ *
+ * Step 1 of the New Project wizard.
+ * Collects project name, category, location, and project type (single vs monorepo).
+ */
+
+import * as React from 'react';
+import { FolderOpen } from 'lucide-react';
+import { Button } from '../ui/Button';
+import { Label } from '../ui/Label';
+import { Input } from '../ui/Input';
+import { ipc } from '../../ipc/client';
+import { cn } from '../../lib/utils';
+import type { WizardConfig } from '../../../main/ipc/channels';
+
+interface WizardStepProps {
+  config: WizardConfig;
+  onChange: (updates: Partial<WizardConfig>) => void;
+}
+
+/** Convert a string to kebab-case, stripping invalid characters */
+function toKebabCase(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+/** Validate a project name (kebab-case, no spaces/special chars) */
+function validateProjectName(name: string): string | null {
+  if (!name) return 'Project name is required';
+  if (/\s/.test(name)) return 'Spaces are not allowed (use hyphens)';
+  if (/[^a-z0-9-]/.test(name)) return 'Only lowercase letters, numbers, and hyphens allowed';
+  if (name.startsWith('-') || name.endsWith('-')) return 'Cannot start or end with a hyphen';
+  if (/--/.test(name)) return 'Cannot contain consecutive hyphens';
+  return null;
+}
+
+export function WizardStepBasics({ config, onChange }: WizardStepProps) {
+  const [nameError, setNameError] = React.useState<string | null>(null);
+  const [rawName, setRawName] = React.useState(config.projectName);
+
+  const handleNameChange = React.useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const raw = e.target.value;
+      setRawName(raw);
+      const kebab = toKebabCase(raw);
+      const error = kebab ? validateProjectName(kebab) : null;
+      setNameError(error);
+      onChange({ projectName: kebab });
+    },
+    [onChange]
+  );
+
+  const handleBrowse = React.useCallback(async () => {
+    try {
+      const result = await ipc.invoke('dialog:open-directory');
+      if (result) {
+        onChange({ location: result as string });
+      }
+    } catch {
+      // User cancelled or dialog error — no action needed
+    }
+  }, [onChange]);
+
+  return (
+    <div className="space-y-4">
+      {/* Project Name */}
+      <div className="space-y-1.5">
+        <Label className="text-[11px] text-muted-foreground">Project Name</Label>
+        <Input
+          type="text"
+          value={rawName}
+          onChange={handleNameChange}
+          placeholder="my-awesome-project"
+          className="h-8 text-[11px] font-mono"
+          data-testid="wizard-project-name"
+        />
+        {rawName && rawName !== config.projectName && (
+          <p className="text-[10px] text-muted-foreground">
+            Will be created as:{' '}
+            <span className="font-mono text-foreground">{config.projectName}</span>
+          </p>
+        )}
+        {nameError && <p className="text-[10px] text-destructive">{nameError}</p>}
+      </div>
+
+      {/* Category (readonly) */}
+      <div className="space-y-1.5">
+        <Label className="text-[11px] text-muted-foreground">Category</Label>
+        <div className="flex h-8 items-center rounded-md border border-input bg-muted/50 px-3">
+          <span className="text-[11px] capitalize text-foreground">{config.category}</span>
+        </div>
+      </div>
+
+      {/* Location */}
+      <div className="space-y-1.5">
+        <Label className="text-[11px] text-muted-foreground">Location</Label>
+        <div className="flex gap-2">
+          <Input
+            type="text"
+            value={config.location}
+            onChange={(e) => onChange({ location: e.target.value })}
+            placeholder="/home/user/projects"
+            className="h-8 text-[11px] font-mono flex-1"
+            data-testid="wizard-location"
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 px-3 text-[11px]"
+            onClick={handleBrowse}
+          >
+            <FolderOpen className="h-3.5 w-3.5 mr-1.5" />
+            Browse
+          </Button>
+        </div>
+        {config.location && config.projectName && (
+          <p className="text-[10px] text-muted-foreground font-mono">
+            {config.location}/{config.projectName}
+          </p>
+        )}
+      </div>
+
+      {/* Project Type */}
+      <div className="space-y-1.5">
+        <Label className="text-[11px] text-muted-foreground">Project Type</Label>
+        <div className="grid grid-cols-2 gap-2">
+          <button
+            type="button"
+            onClick={() => onChange({ projectType: 'single' })}
+            className={cn(
+              'flex flex-col items-center gap-1.5 rounded-md border p-3 text-center transition-colors',
+              config.projectType === 'single'
+                ? 'border-primary bg-primary/10 text-foreground'
+                : 'border-input bg-background text-muted-foreground hover:border-primary/50'
+            )}
+          >
+            <span className="text-[11px] font-medium">Single Project</span>
+            <span className="text-[10px] text-muted-foreground">Standard project structure</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => onChange({ projectType: 'monorepo' })}
+            className={cn(
+              'flex flex-col items-center gap-1.5 rounded-md border p-3 text-center transition-colors',
+              config.projectType === 'monorepo'
+                ? 'border-primary bg-primary/10 text-foreground'
+                : 'border-input bg-background text-muted-foreground hover:border-primary/50'
+            )}
+          >
+            <span className="text-[11px] font-medium">Monorepo</span>
+            <span className="text-[10px] text-muted-foreground">Multiple packages in one repo</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/projects/WizardStepDatabase.tsx
+++ b/src/renderer/components/projects/WizardStepDatabase.tsx
@@ -1,0 +1,217 @@
+/**
+ * WizardStepDatabase
+ *
+ * Step 4 of the New Project wizard.
+ * Configures database engine, ORM/driver, Docker Compose, .env vars, and additional engines.
+ */
+
+import * as React from 'react';
+import { Label } from '../ui/Label';
+import { Checkbox } from '../ui/Checkbox';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/Select';
+import { cn } from '../../lib/utils';
+import type { WizardConfig, ORMOption } from '../../../main/ipc/channels';
+
+interface WizardStepProps {
+  config: WizardConfig;
+  onChange: (updates: Partial<WizardConfig>) => void;
+}
+
+interface WizardStepDatabaseProps extends WizardStepProps {
+  ormOptions: ORMOption[];
+}
+
+interface EngineCard {
+  id: WizardConfig['database']['engine'];
+  label: string;
+  icon: string;
+}
+
+const DATABASE_ENGINES: EngineCard[] = [
+  { id: 'none', label: 'None', icon: '--' },
+  { id: 'postgresql', label: 'PostgreSQL', icon: 'PG' },
+  { id: 'mysql', label: 'MySQL', icon: 'MY' },
+  { id: 'mongodb', label: 'MongoDB', icon: 'MG' },
+  { id: 'sqlite', label: 'SQLite', icon: 'SL' },
+  { id: 'redis', label: 'Redis', icon: 'RD' },
+];
+
+/** Additional engines that can be added alongside the primary DB */
+const ADDITIONAL_ENGINES = [
+  { id: 'redis', label: 'Redis' },
+  { id: 'postgresql', label: 'PostgreSQL' },
+  { id: 'mysql', label: 'MySQL' },
+  { id: 'mongodb', label: 'MongoDB' },
+];
+
+export function WizardStepDatabase({ config, onChange, ormOptions }: WizardStepDatabaseProps) {
+  const hasEngine = config.database.engine !== 'none';
+
+  const handleDatabaseChange = React.useCallback(
+    (key: keyof WizardConfig['database'], value: unknown) => {
+      onChange({
+        database: { ...config.database, [key]: value },
+      });
+    },
+    [config.database, onChange]
+  );
+
+  const handleEngineSelect = React.useCallback(
+    (engine: WizardConfig['database']['engine']) => {
+      const isNone = engine === 'none';
+      onChange({
+        database: {
+          ...config.database,
+          engine,
+          orm: undefined,
+          includeDocker: !isNone,
+          includeEnvVars: !isNone,
+          additionalEngines: isNone
+            ? []
+            : config.database.additionalEngines.filter((e) => e !== engine),
+        },
+      });
+    },
+    [config.database, onChange]
+  );
+
+  const handleAdditionalEngineToggle = React.useCallback(
+    (engineId: string) => {
+      const current = config.database.additionalEngines;
+      const updated = current.includes(engineId)
+        ? current.filter((e) => e !== engineId)
+        : [...current, engineId];
+      handleDatabaseChange('additionalEngines', updated);
+    },
+    [config.database.additionalEngines, handleDatabaseChange]
+  );
+
+  // Filter out the primary engine from additional engine options
+  const availableAdditionalEngines = ADDITIONAL_ENGINES.filter(
+    (e) => e.id !== config.database.engine
+  );
+
+  return (
+    <div className="space-y-4">
+      {/* Database Engine Grid */}
+      <div className="space-y-1.5">
+        <Label className="text-[11px] text-muted-foreground">Database Engine</Label>
+        <div className="grid grid-cols-3 gap-2">
+          {DATABASE_ENGINES.map((db) => (
+            <button
+              key={db.id}
+              type="button"
+              onClick={() => handleEngineSelect(db.id)}
+              className={cn(
+                'flex flex-col items-center gap-1 rounded-md border p-2.5 transition-colors',
+                config.database.engine === db.id
+                  ? 'border-primary bg-primary/10 text-foreground'
+                  : 'border-input bg-background text-muted-foreground hover:border-primary/50'
+              )}
+            >
+              <span className="text-[11px] font-bold tracking-wider">{db.icon}</span>
+              <span className="text-[10px]">{db.label}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* ORM/Driver (only when engine is selected) */}
+      {hasEngine && ormOptions.length > 0 && (
+        <div className="space-y-1.5">
+          <Label className="text-[11px] text-muted-foreground">ORM / Driver</Label>
+          <Select
+            value={config.database.orm ?? ''}
+            onValueChange={(value) => handleDatabaseChange('orm', value || undefined)}
+          >
+            <SelectTrigger className="h-8 text-[11px]">
+              <SelectValue placeholder="Select ORM or driver..." />
+            </SelectTrigger>
+            <SelectContent>
+              {ormOptions.map((orm) => (
+                <SelectItem key={orm.id} value={orm.id} className="text-[11px]">
+                  <span className="flex items-center gap-1.5">
+                    {orm.name}
+                    {orm.recommended && (
+                      <span className="text-[9px] text-primary font-medium px-1 py-0.5 bg-primary/10 rounded">
+                        recommended
+                      </span>
+                    )}
+                  </span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      {/* Docker & Env Options (only when engine is selected) */}
+      {hasEngine && (
+        <div className="space-y-2">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <Checkbox
+              checked={config.database.includeDocker}
+              onCheckedChange={(checked) => handleDatabaseChange('includeDocker', checked === true)}
+              className="h-3.5 w-3.5"
+            />
+            <span className="text-[11px] text-foreground">Include Docker Compose</span>
+            <span className="text-[10px] text-muted-foreground">
+              docker-compose.yml with database service
+            </span>
+          </label>
+
+          <label className="flex items-center gap-2 cursor-pointer">
+            <Checkbox
+              checked={config.database.includeEnvVars}
+              onCheckedChange={(checked) =>
+                handleDatabaseChange('includeEnvVars', checked === true)
+              }
+              className="h-3.5 w-3.5"
+            />
+            <span className="text-[11px] text-foreground">Include .env variables</span>
+            <span className="text-[10px] text-muted-foreground">
+              Database connection string and credentials
+            </span>
+          </label>
+        </div>
+      )}
+
+      {/* Additional Engines */}
+      {hasEngine && availableAdditionalEngines.length > 0 && (
+        <div className="space-y-1.5">
+          <Label className="text-[11px] text-muted-foreground">Additional Engines</Label>
+          <p className="text-[10px] text-muted-foreground">
+            Add supplementary services alongside {config.database.engine}
+          </p>
+          <div className="flex flex-wrap gap-2 mt-1">
+            {availableAdditionalEngines.map((engine) => {
+              const isSelected = config.database.additionalEngines.includes(engine.id);
+              return (
+                <button
+                  key={engine.id}
+                  type="button"
+                  onClick={() => handleAdditionalEngineToggle(engine.id)}
+                  className={cn(
+                    'rounded-full border px-2.5 py-1 text-[10px] transition-colors',
+                    isSelected
+                      ? 'border-primary bg-primary/10 text-foreground'
+                      : 'border-input bg-background text-muted-foreground hover:border-primary/50'
+                  )}
+                >
+                  {engine.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* No database selected info */}
+      {!hasEngine && (
+        <p className="text-[10px] text-muted-foreground text-center py-4">
+          No database selected. You can always add one later.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/components/projects/WizardStepEcosystem.tsx
+++ b/src/renderer/components/projects/WizardStepEcosystem.tsx
@@ -1,0 +1,375 @@
+/**
+ * WizardStepEcosystem
+ *
+ * Step 2 of the New Project wizard.
+ * Selects ecosystem, framework, monorepo tool, and package manager.
+ * Shows inline validation banner when a selected PM is not installed.
+ */
+
+import * as React from 'react';
+import { Loader2, AlertTriangle, Check } from 'lucide-react';
+import { Label } from '../ui/Label';
+import { Button } from '../ui/Button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/Select';
+import { cn } from '../../lib/utils';
+import type { WizardConfig, Ecosystem } from '../../../main/ipc/channels';
+
+interface WizardStepProps {
+  config: WizardConfig;
+  onChange: (updates: Partial<WizardConfig>) => void;
+}
+
+export interface ToolValidationState {
+  status: 'idle' | 'checking' | 'missing' | 'installing' | 'installed' | 'error';
+  toolName: string;
+  errorMessage?: string;
+  installedVersion?: string;
+  alternatives: { value: string; label: string }[];
+}
+
+interface WizardStepEcosystemProps extends WizardStepProps {
+  toolValidation?: ToolValidationState;
+  onInstallTool?: () => void;
+  onDismissValidation?: () => void;
+}
+
+interface EcosystemCard {
+  id: Ecosystem;
+  label: string;
+  icon: string;
+}
+
+const ECOSYSTEMS: EcosystemCard[] = [
+  { id: 'node', label: 'Node.js', icon: 'JS' },
+  { id: 'python', label: 'Python', icon: 'PY' },
+  { id: 'rust', label: 'Rust', icon: 'RS' },
+  { id: 'go', label: 'Go', icon: 'GO' },
+  { id: 'ruby', label: 'Ruby', icon: 'RB' },
+  { id: 'php', label: 'PHP', icon: 'PHP' },
+  { id: 'java', label: 'Java', icon: 'JV' },
+];
+
+const FRAMEWORKS: Record<string, { value: string; label: string }[]> = {
+  node: [
+    { value: 'react', label: 'React' },
+    { value: 'nextjs', label: 'Next.js' },
+    { value: 'express', label: 'Express' },
+    { value: 'vanilla-ts', label: 'Vanilla TS' },
+    { value: 'none', label: 'None' },
+  ],
+  python: [
+    { value: 'django', label: 'Django' },
+    { value: 'flask', label: 'Flask' },
+    { value: 'fastapi', label: 'FastAPI' },
+    { value: 'none', label: 'None' },
+  ],
+  rust: [],
+  go: [],
+  ruby: [
+    { value: 'rails', label: 'Rails' },
+    { value: 'sinatra', label: 'Sinatra' },
+    { value: 'none', label: 'None' },
+  ],
+  php: [
+    { value: 'laravel', label: 'Laravel' },
+    { value: 'symfony', label: 'Symfony' },
+    { value: 'none', label: 'None' },
+  ],
+  java: [
+    { value: 'spring-boot', label: 'Spring Boot' },
+    { value: 'none', label: 'None' },
+  ],
+};
+
+const MONOREPO_TOOLS: Record<string, { value: string; label: string }[]> = {
+  node: [
+    { value: 'turborepo', label: 'Turborepo' },
+    { value: 'nx', label: 'Nx' },
+    { value: 'pnpm-workspaces', label: 'pnpm workspaces' },
+  ],
+  rust: [{ value: 'cargo-workspaces', label: 'Cargo workspaces' }],
+  go: [{ value: 'go-workspaces', label: 'Go workspaces' }],
+  python: [{ value: 'uv-workspaces', label: 'uv workspaces' }],
+  ruby: [],
+  php: [],
+  java: [],
+};
+
+export const PACKAGE_MANAGERS: Record<
+  string,
+  { value: string; label: string; readonly?: boolean }[]
+> = {
+  node: [
+    { value: 'npm', label: 'npm' },
+    { value: 'yarn', label: 'yarn' },
+    { value: 'pnpm', label: 'pnpm' },
+    { value: 'bun', label: 'bun' },
+  ],
+  python: [
+    { value: 'pip', label: 'pip' },
+    { value: 'poetry', label: 'poetry' },
+    { value: 'uv', label: 'uv' },
+  ],
+  rust: [{ value: 'cargo', label: 'cargo', readonly: true }],
+  go: [{ value: 'go', label: 'go', readonly: true }],
+  ruby: [{ value: 'bundler', label: 'bundler', readonly: true }],
+  php: [{ value: 'composer', label: 'composer', readonly: true }],
+  java: [
+    { value: 'maven', label: 'Maven' },
+    { value: 'gradle', label: 'Gradle' },
+  ],
+};
+
+/** Get the default package manager for an ecosystem */
+function getDefaultPackageManager(ecosystem: Ecosystem): string {
+  const managers = PACKAGE_MANAGERS[ecosystem];
+  return managers?.[0]?.value ?? 'unknown';
+}
+
+export function WizardStepEcosystem({
+  config,
+  onChange,
+  toolValidation,
+  onInstallTool,
+  onDismissValidation,
+}: WizardStepEcosystemProps) {
+  const frameworks = FRAMEWORKS[config.ecosystem] ?? [];
+  const monorepoTools = MONOREPO_TOOLS[config.ecosystem] ?? [];
+  const packageManagers = PACKAGE_MANAGERS[config.ecosystem] ?? [];
+  const isPackageManagerReadonly = packageManagers.length === 1 && packageManagers[0]?.readonly;
+  const showMonorepoTool = config.projectType === 'monorepo' && monorepoTools.length > 0;
+
+  const handleEcosystemChange = React.useCallback(
+    (ecosystem: Ecosystem) => {
+      const defaultPm = getDefaultPackageManager(ecosystem);
+      const newFrameworks = FRAMEWORKS[ecosystem] ?? [];
+      const newMonorepoTools = MONOREPO_TOOLS[ecosystem] ?? [];
+
+      onChange({
+        ecosystem,
+        packageManager: defaultPm,
+        framework: newFrameworks.length > 0 ? undefined : undefined,
+        monorepoTool: newMonorepoTools.length > 0 ? newMonorepoTools[0].value : undefined,
+      });
+    },
+    [onChange]
+  );
+
+  const showValidation = toolValidation && toolValidation.status !== 'idle';
+
+  return (
+    <div className="space-y-4">
+      {/* Ecosystem Grid */}
+      <div className="space-y-1.5">
+        <Label className="text-[11px] text-muted-foreground">Ecosystem</Label>
+        <div className="grid grid-cols-4 gap-2">
+          {ECOSYSTEMS.map((eco) => (
+            <button
+              key={eco.id}
+              type="button"
+              onClick={() => handleEcosystemChange(eco.id)}
+              className={cn(
+                'flex flex-col items-center gap-1 rounded-md border p-2.5 transition-colors',
+                config.ecosystem === eco.id
+                  ? 'border-primary bg-primary/10 text-foreground'
+                  : 'border-input bg-background text-muted-foreground hover:border-primary/50'
+              )}
+            >
+              <span className="text-[11px] font-bold tracking-wider">{eco.icon}</span>
+              <span className="text-[10px]">{eco.label}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Framework */}
+      {frameworks.length > 0 && (
+        <div className="space-y-1.5">
+          <Label className="text-[11px] text-muted-foreground">Framework</Label>
+          <Select
+            value={config.framework ?? ''}
+            onValueChange={(value) => onChange({ framework: value === 'none' ? undefined : value })}
+          >
+            <SelectTrigger className="h-8 text-[11px]">
+              <SelectValue placeholder="Select framework..." />
+            </SelectTrigger>
+            <SelectContent>
+              {frameworks.map((fw) => (
+                <SelectItem key={fw.value} value={fw.value} className="text-[11px]">
+                  {fw.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      {/* Monorepo Tool */}
+      {showMonorepoTool && (
+        <div className="space-y-1.5">
+          <Label className="text-[11px] text-muted-foreground">Monorepo Tool</Label>
+          <Select
+            value={config.monorepoTool ?? ''}
+            onValueChange={(value) => onChange({ monorepoTool: value })}
+          >
+            <SelectTrigger className="h-8 text-[11px]">
+              <SelectValue placeholder="Select monorepo tool..." />
+            </SelectTrigger>
+            <SelectContent>
+              {monorepoTools.map((tool) => (
+                <SelectItem key={tool.value} value={tool.value} className="text-[11px]">
+                  {tool.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      {/* Package Manager */}
+      <div className="space-y-1.5">
+        <Label className="text-[11px] text-muted-foreground">Package Manager</Label>
+        {isPackageManagerReadonly ? (
+          <div className="flex h-8 items-center rounded-md border border-input bg-muted/50 px-3">
+            <span className="text-[11px] text-foreground">{packageManagers[0].label}</span>
+          </div>
+        ) : (
+          <Select
+            value={config.packageManager}
+            onValueChange={(value) => onChange({ packageManager: value })}
+          >
+            <SelectTrigger className="h-8 text-[11px]">
+              <SelectValue placeholder="Select package manager..." />
+            </SelectTrigger>
+            <SelectContent>
+              {packageManagers.map((pm) => (
+                <SelectItem key={pm.value} value={pm.value} className="text-[11px]">
+                  {pm.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+      </div>
+
+      {/* Tool Validation Banner */}
+      {showValidation && (
+        <div className="mt-1">
+          {toolValidation.status === 'checking' && (
+            <div className="flex items-center gap-2 p-2 rounded-md bg-muted/50 border border-border">
+              <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+              <span className="text-[10px] text-muted-foreground">
+                Checking if {toolValidation.toolName} is installed...
+              </span>
+            </div>
+          )}
+
+          {toolValidation.status === 'missing' && (
+            <div className="p-3 rounded-md bg-yellow-500/10 border border-yellow-500/30 space-y-2">
+              <div className="flex items-start gap-2">
+                <AlertTriangle className="h-3.5 w-3.5 text-yellow-500 shrink-0 mt-0.5" />
+                <div className="space-y-1">
+                  <p className="text-[11px] font-medium text-yellow-600 dark:text-yellow-400">
+                    {toolValidation.toolName} is not installed
+                  </p>
+                  <p className="text-[10px] text-muted-foreground">
+                    The scaffold command requires {toolValidation.toolName} to be available on your
+                    system.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex flex-wrap gap-1.5 pt-1">
+                {toolValidation.alternatives.map((alt) => (
+                  <Button
+                    key={alt.value}
+                    variant="outline"
+                    size="sm"
+                    className="h-7 text-[10px]"
+                    onClick={() => {
+                      onChange({ packageManager: alt.value });
+                      onDismissValidation?.();
+                    }}
+                  >
+                    Use {alt.label} instead
+                  </Button>
+                ))}
+
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  className="h-7 text-[10px]"
+                  onClick={onInstallTool}
+                >
+                  Install {toolValidation.toolName}
+                </Button>
+
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 text-[10px] text-muted-foreground"
+                  onClick={onDismissValidation}
+                >
+                  Continue anyway
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {toolValidation.status === 'installing' && (
+            <div className="flex items-center gap-2 p-2 rounded-md bg-blue-500/10 border border-blue-500/30">
+              <Loader2 className="h-3.5 w-3.5 animate-spin text-blue-500" />
+              <span className="text-[10px] text-blue-600 dark:text-blue-400">
+                Installing {toolValidation.toolName}... This may take a moment.
+              </span>
+            </div>
+          )}
+
+          {toolValidation.status === 'installed' && (
+            <div className="flex items-center gap-2 p-2 rounded-md bg-green-500/10 border border-green-500/30">
+              <Check className="h-3.5 w-3.5 text-green-500" />
+              <span className="text-[10px] text-green-600 dark:text-green-400">
+                {toolValidation.toolName}
+                {toolValidation.installedVersion ? ` v${toolValidation.installedVersion}` : ''}{' '}
+                installed successfully
+              </span>
+            </div>
+          )}
+
+          {toolValidation.status === 'error' && (
+            <div className="p-2.5 rounded-md bg-destructive/10 border border-destructive/30 space-y-1.5">
+              <div className="flex items-start gap-2">
+                <AlertTriangle className="h-3.5 w-3.5 text-destructive shrink-0 mt-0.5" />
+                <p className="text-[10px] text-destructive">{toolValidation.errorMessage}</p>
+              </div>
+              <div className="flex gap-1.5">
+                {toolValidation.alternatives.map((alt) => (
+                  <Button
+                    key={alt.value}
+                    variant="outline"
+                    size="sm"
+                    className="h-6 text-[10px]"
+                    onClick={() => {
+                      onChange({ packageManager: alt.value });
+                      onDismissValidation?.();
+                    }}
+                  >
+                    Use {alt.label}
+                  </Button>
+                ))}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 text-[10px] text-muted-foreground"
+                  onClick={onDismissValidation}
+                >
+                  Dismiss
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/components/projects/WizardStepGitHubConfig.tsx
+++ b/src/renderer/components/projects/WizardStepGitHubConfig.tsx
@@ -1,0 +1,228 @@
+/**
+ * WizardStepGitHubConfig
+ *
+ * Step 5 of the New Project wizard.
+ * Checklist of all 12 GitHub config templates grouped by tier (Repository / Community).
+ * Selected templates are stored in config.githubConfigSelections.
+ */
+
+import * as React from 'react';
+import { Loader2 } from 'lucide-react';
+import { Checkbox } from '../ui/Checkbox';
+import { cn } from '../../lib/utils';
+import type {
+  WizardConfig,
+  ProjectGitHubConfigSelection,
+  GitHubConfigTemplate,
+} from '../../../main/ipc/channels';
+
+interface WizardStepProps {
+  config: WizardConfig;
+  onChange: (updates: Partial<WizardConfig>) => void;
+}
+
+interface WizardStepGitHubConfigProps extends WizardStepProps {
+  templates: Record<string, GitHubConfigTemplate[]>;
+  loading: boolean;
+}
+
+/**
+ * Feature display metadata grouped by tier, matching github-config.service.ts FEATURES.
+ * Order within each tier matches the service definition.
+ */
+const FEATURE_TIERS: { tier: string; features: { id: string; label: string }[] }[] = [
+  {
+    tier: 'Repository',
+    features: [
+      { id: 'workflows', label: 'Workflows' },
+      { id: 'dependabot', label: 'Dependabot' },
+      { id: 'release-notes', label: 'Release Notes' },
+      { id: 'issue-templates', label: 'Issue Templates' },
+      { id: 'pr-template', label: 'PR Template' },
+      { id: 'labeler', label: 'Labeler' },
+      { id: 'codeowners', label: 'CODEOWNERS' },
+    ],
+  },
+  {
+    tier: 'Community',
+    features: [
+      { id: 'auto-assign', label: 'Auto-Assign' },
+      { id: 'copilot-instructions', label: 'Copilot Instructions' },
+      { id: 'funding', label: 'Funding' },
+      { id: 'security', label: 'Security Policy' },
+      { id: 'stale', label: 'Stale' },
+    ],
+  },
+];
+
+export function WizardStepGitHubConfig({
+  config,
+  onChange,
+  templates,
+  loading,
+}: WizardStepGitHubConfigProps) {
+  const selections = config.githubConfigSelections;
+
+  const isSelected = React.useCallback(
+    (templateId: string) => {
+      return selections.some((s) => s.templateId === templateId);
+    },
+    [selections]
+  );
+
+  const handleToggle = React.useCallback(
+    (template: GitHubConfigTemplate, featureId: string) => {
+      const existing = selections.find((s) => s.templateId === template.id);
+      let updated: ProjectGitHubConfigSelection[];
+
+      if (existing) {
+        updated = selections.filter((s) => s.templateId !== template.id);
+      } else {
+        updated = [...selections, { featureId, templateId: template.id }];
+      }
+
+      onChange({ githubConfigSelections: updated });
+    },
+    [selections, onChange]
+  );
+
+  const handleSelectAllFeature = React.useCallback(
+    (featureId: string, featureTemplates: GitHubConfigTemplate[]) => {
+      const allSelected = featureTemplates.every((t) => isSelected(t.id));
+
+      let updated: ProjectGitHubConfigSelection[];
+      if (allSelected) {
+        const templateIds = new Set(featureTemplates.map((t) => t.id));
+        updated = selections.filter((s) => !templateIds.has(s.templateId));
+      } else {
+        const existingIds = new Set(selections.map((s) => s.templateId));
+        const newSelections = featureTemplates
+          .filter((t) => !existingIds.has(t.id))
+          .map((t) => ({ featureId, templateId: t.id }));
+        updated = [...selections, ...newSelections];
+      }
+
+      onChange({ githubConfigSelections: updated });
+    },
+    [selections, isSelected, onChange]
+  );
+
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 gap-3 text-muted-foreground">
+        <Loader2 className="h-6 w-6 animate-spin" />
+        <p className="text-[11px]">Loading GitHub config templates...</p>
+      </div>
+    );
+  }
+
+  // Filter tiers to only those with at least one feature that has templates
+  const activeTiers = FEATURE_TIERS.map((tier) => ({
+    ...tier,
+    features: tier.features.filter((f) => templates[f.id] && templates[f.id].length > 0),
+  })).filter((tier) => tier.features.length > 0);
+
+  if (activeTiers.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+        <p className="text-[11px]">No GitHub config templates available.</p>
+        <p className="text-[10px] mt-1">Templates will be generated based on your ecosystem.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-[10px] text-muted-foreground">
+        Select GitHub configuration files to include in your project.
+        {selections.length > 0 && (
+          <span className="text-foreground font-medium ml-1">{selections.length} selected</span>
+        )}
+      </p>
+
+      {activeTiers.map((tier) => (
+        <div key={tier.tier} className="space-y-2">
+          {/* Tier heading */}
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              {tier.tier}
+            </span>
+            <div className="flex-1 h-px bg-border" />
+          </div>
+
+          {/* Features within the tier */}
+          {tier.features.map((feature) => {
+            const featureTemplates = templates[feature.id];
+            const allSelected = featureTemplates.every((t) => isSelected(t.id));
+            const someSelected = featureTemplates.some((t) => isSelected(t.id));
+            const singleTemplate = featureTemplates.length === 1;
+
+            // Single-template features: one checkbox row (no expand)
+            if (singleTemplate) {
+              const template = featureTemplates[0];
+              return (
+                <label
+                  key={feature.id}
+                  className="flex items-start gap-2 cursor-pointer py-1.5 px-2 rounded hover:bg-muted/50 transition-colors"
+                >
+                  <Checkbox
+                    checked={isSelected(template.id)}
+                    onCheckedChange={() => handleToggle(template, feature.id)}
+                    className="h-3.5 w-3.5 mt-0.5"
+                  />
+                  <div className="min-w-0">
+                    <span className="text-[11px] text-foreground">{feature.label}</span>
+                    <p className="text-[10px] text-muted-foreground leading-tight">
+                      {template.description}
+                    </p>
+                  </div>
+                </label>
+              );
+            }
+
+            // Multi-template features: group header with select-all + children
+            return (
+              <div key={feature.id} className="space-y-1">
+                <div className="flex items-center gap-2">
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <Checkbox
+                      checked={allSelected}
+                      onCheckedChange={() => handleSelectAllFeature(feature.id, featureTemplates)}
+                      className={cn('h-3.5 w-3.5', someSelected && !allSelected && 'opacity-60')}
+                    />
+                    <span className="text-[11px] font-medium text-foreground">{feature.label}</span>
+                  </label>
+                  <span className="text-[10px] text-muted-foreground">
+                    {featureTemplates.filter((t) => isSelected(t.id)).length}/
+                    {featureTemplates.length}
+                  </span>
+                </div>
+
+                <div className="space-y-1 pl-2 ml-1 border-l border-border">
+                  {featureTemplates.map((template) => (
+                    <label
+                      key={template.id}
+                      className="flex items-start gap-2 cursor-pointer py-1 px-1.5 rounded hover:bg-muted/50 transition-colors"
+                    >
+                      <Checkbox
+                        checked={isSelected(template.id)}
+                        onCheckedChange={() => handleToggle(template, feature.id)}
+                        className="h-3.5 w-3.5 mt-0.5"
+                      />
+                      <div className="min-w-0">
+                        <span className="text-[11px] text-foreground">{template.label}</span>
+                        <p className="text-[10px] text-muted-foreground leading-tight">
+                          {template.description}
+                        </p>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/renderer/components/projects/WizardStepOptions.tsx
+++ b/src/renderer/components/projects/WizardStepOptions.tsx
@@ -1,0 +1,212 @@
+/**
+ * WizardStepOptions
+ *
+ * Step 3 of the New Project wizard.
+ * Configures GitHub repo creation, extras (.gitignore, .editorconfig, etc.), and license.
+ */
+
+import * as React from 'react';
+import { Label } from '../ui/Label';
+import { Input } from '../ui/Input';
+import { Checkbox } from '../ui/Checkbox';
+import { Switch } from '../ui/Switch';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/Select';
+import { cn } from '../../lib/utils';
+import type { WizardConfig } from '../../../main/ipc/channels';
+
+interface WizardStepProps {
+  config: WizardConfig;
+  onChange: (updates: Partial<WizardConfig>) => void;
+}
+
+const LICENSES = [
+  { value: 'MIT', label: 'MIT' },
+  { value: 'Apache-2.0', label: 'Apache 2.0' },
+  { value: 'GPL-3.0', label: 'GPL 3.0' },
+  { value: 'BSD-2-Clause', label: 'BSD 2-Clause' },
+  { value: 'ISC', label: 'ISC' },
+  { value: 'Unlicense', label: 'Unlicense' },
+  { value: 'none', label: 'None' },
+];
+
+export function WizardStepOptions({ config, onChange }: WizardStepProps) {
+  const handleExtrasChange = React.useCallback(
+    (key: keyof WizardConfig['extras'], value: boolean | string | null) => {
+      onChange({
+        extras: { ...config.extras, [key]: value },
+      });
+    },
+    [config.extras, onChange]
+  );
+
+  return (
+    <div className="space-y-5">
+      {/* GitHub Section */}
+      <div className="space-y-3">
+        <div className="flex items-center gap-2">
+          <h4 className="text-[11px] font-medium text-foreground">GitHub</h4>
+          <div className="flex-1 h-px bg-border" />
+        </div>
+
+        {/* Create Remote Repo Toggle */}
+        <div className="flex items-center justify-between">
+          <div>
+            <Label className="text-[11px] text-foreground">Create remote repository</Label>
+            <p className="text-[10px] text-muted-foreground">
+              Create a new GitHub repository for this project
+            </p>
+          </div>
+          <Switch
+            checked={config.createGitHubRepo}
+            onCheckedChange={(checked) => onChange({ createGitHubRepo: checked })}
+          />
+        </div>
+
+        {/* Conditional GitHub fields */}
+        {config.createGitHubRepo && (
+          <div className="space-y-3 pl-2 border-l-2 border-primary/20 ml-1">
+            {/* Visibility */}
+            <div className="space-y-1.5">
+              <Label className="text-[11px] text-muted-foreground">Visibility</Label>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => onChange({ repoVisibility: 'public' })}
+                  className={cn(
+                    'flex-1 rounded-md border px-3 py-1.5 text-[11px] text-center transition-colors',
+                    config.repoVisibility === 'public'
+                      ? 'border-primary bg-primary/10 text-foreground'
+                      : 'border-input bg-background text-muted-foreground hover:border-primary/50'
+                  )}
+                >
+                  Public
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onChange({ repoVisibility: 'private' })}
+                  className={cn(
+                    'flex-1 rounded-md border px-3 py-1.5 text-[11px] text-center transition-colors',
+                    config.repoVisibility === 'private'
+                      ? 'border-primary bg-primary/10 text-foreground'
+                      : 'border-input bg-background text-muted-foreground hover:border-primary/50'
+                  )}
+                >
+                  Private
+                </button>
+              </div>
+            </div>
+
+            {/* Description */}
+            <div className="space-y-1.5">
+              <Label className="text-[11px] text-muted-foreground">Description</Label>
+              <Input
+                type="text"
+                value={config.repoDescription}
+                onChange={(e) => onChange({ repoDescription: e.target.value })}
+                placeholder="A short description of this project"
+                className="h-8 text-[11px]"
+                data-testid="wizard-repo-description"
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Extras Section */}
+      <div className="space-y-3">
+        <div className="flex items-center gap-2">
+          <h4 className="text-[11px] font-medium text-foreground">Extras</h4>
+          <div className="flex-1 h-px bg-border" />
+        </div>
+
+        <div className="space-y-2">
+          {/* .gitignore */}
+          <label className="flex items-center gap-2 cursor-pointer">
+            <Checkbox
+              checked={config.extras.gitignore}
+              onCheckedChange={(checked) => handleExtrasChange('gitignore', checked === true)}
+              className="h-3.5 w-3.5"
+            />
+            <span className="text-[11px] text-foreground">.gitignore</span>
+            <span className="text-[10px] text-muted-foreground">
+              Ignore build artifacts and dependencies
+            </span>
+          </label>
+
+          {/* .editorconfig */}
+          <label className="flex items-center gap-2 cursor-pointer">
+            <Checkbox
+              checked={config.extras.editorconfig}
+              onCheckedChange={(checked) => handleExtrasChange('editorconfig', checked === true)}
+              className="h-3.5 w-3.5"
+            />
+            <span className="text-[11px] text-foreground">.editorconfig</span>
+            <span className="text-[10px] text-muted-foreground">
+              Consistent editor settings across IDEs
+            </span>
+          </label>
+
+          {/* .env file */}
+          <label className="flex items-center gap-2 cursor-pointer">
+            <Checkbox
+              checked={config.extras.envFile}
+              onCheckedChange={(checked) => handleExtrasChange('envFile', checked === true)}
+              className="h-3.5 w-3.5"
+            />
+            <span className="text-[11px] text-foreground">.env file</span>
+            <span className="text-[10px] text-muted-foreground">
+              Environment variables template
+            </span>
+          </label>
+
+          {/* Git hooks */}
+          <label className="flex items-center gap-2 cursor-pointer">
+            <Checkbox
+              checked={config.extras.hooks}
+              onCheckedChange={(checked) => handleExtrasChange('hooks', checked === true)}
+              className="h-3.5 w-3.5"
+            />
+            <span className="text-[11px] text-foreground">Git hooks</span>
+            <span className="text-[10px] text-muted-foreground">
+              Pre-commit and commit-msg hooks
+            </span>
+          </label>
+
+          {/* README.md */}
+          <label className="flex items-center gap-2 cursor-pointer">
+            <Checkbox
+              checked={config.extras.readme}
+              onCheckedChange={(checked) => handleExtrasChange('readme', checked === true)}
+              className="h-3.5 w-3.5"
+            />
+            <span className="text-[11px] text-foreground">README.md</span>
+            <span className="text-[10px] text-muted-foreground">Project documentation starter</span>
+          </label>
+        </div>
+      </div>
+
+      {/* License */}
+      <div className="space-y-1.5">
+        <div className="flex items-center gap-2">
+          <h4 className="text-[11px] font-medium text-foreground">License</h4>
+          <div className="flex-1 h-px bg-border" />
+        </div>
+        <Select
+          value={config.extras.license ?? 'none'}
+          onValueChange={(value) => handleExtrasChange('license', value === 'none' ? null : value)}
+        >
+          <SelectTrigger className="h-8 text-[11px]">
+            <SelectValue placeholder="Select license..." />
+          </SelectTrigger>
+          <SelectContent>
+            {LICENSES.map((lic) => (
+              <SelectItem key={lic.value} value={lic.value} className="text-[11px]">
+                {lic.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/projects/WizardStepReview.tsx
+++ b/src/renderer/components/projects/WizardStepReview.tsx
@@ -1,0 +1,227 @@
+/**
+ * WizardStepReview
+ *
+ * Step 6 (final) of the New Project wizard.
+ * Two modes:
+ *   1. Review mode (status === 'idle'): Summary of all selected options.
+ *   2. Creation mode (status !== 'idle'): Progress bar, current step, errors/warnings.
+ */
+
+import * as React from 'react';
+import { Check, AlertCircle, AlertTriangle, Loader2 } from 'lucide-react';
+import { Progress } from '../ui/Progress';
+import { cn } from '../../lib/utils';
+import type { WizardConfig } from '../../../main/ipc/channels';
+
+interface WizardStepProps {
+  config: WizardConfig;
+  onChange: (updates: Partial<WizardConfig>) => void;
+}
+
+interface CreationState {
+  status: string;
+  progress: number;
+  currentStep: string;
+  error: string | null;
+  warnings: string[];
+}
+
+interface WizardStepReviewProps extends WizardStepProps {
+  creationState: CreationState;
+}
+
+/** Render a key-value row in the review summary */
+function ReviewRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4 py-1">
+      <span className="text-[10px] text-muted-foreground shrink-0">{label}</span>
+      <span className="text-[11px] text-foreground text-right truncate">{value}</span>
+    </div>
+  );
+}
+
+/** Render a section heading in the review summary */
+function ReviewSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-2 pt-1">
+        <h4 className="text-[11px] font-medium text-foreground">{title}</h4>
+        <div className="flex-1 h-px bg-border" />
+      </div>
+      <div className="divide-y divide-border/50">{children}</div>
+    </div>
+  );
+}
+
+export function WizardStepReview({ config, creationState }: WizardStepReviewProps) {
+  const isCreating = creationState.status !== 'idle';
+  const isError = creationState.status === 'error';
+  const isComplete = creationState.status === 'complete';
+
+  // ---------- Creation Mode ----------
+  if (isCreating) {
+    return (
+      <div className="space-y-4">
+        {/* Progress Bar */}
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-[11px] font-medium text-foreground">
+              {isComplete ? 'Project created' : isError ? 'Creation failed' : 'Creating project...'}
+            </span>
+            <span className="text-[10px] text-muted-foreground">
+              {Math.round(creationState.progress)}%
+            </span>
+          </div>
+          <Progress
+            value={creationState.progress}
+            className={cn('h-2', isError && '[&>div]:bg-destructive')}
+          />
+        </div>
+
+        {/* Current Step */}
+        {!isError && !isComplete && (
+          <div className="flex items-center gap-2 py-2">
+            <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" />
+            <span className="text-[11px] text-muted-foreground">{creationState.currentStep}</span>
+          </div>
+        )}
+
+        {/* Complete Indicator */}
+        {isComplete && (
+          <div className="flex items-center gap-2 py-2 text-green-500">
+            <Check className="h-4 w-4" />
+            <span className="text-[11px] font-medium">
+              Project created successfully at {config.location}/{config.projectName}
+            </span>
+          </div>
+        )}
+
+        {/* Error Display */}
+        {isError && creationState.error && (
+          <div className="flex items-start gap-2 p-3 rounded-md bg-destructive/10 border border-destructive/30">
+            <AlertCircle className="h-4 w-4 text-destructive shrink-0 mt-0.5" />
+            <div>
+              <p className="text-[11px] font-medium text-destructive">Error</p>
+              <p className="text-[10px] text-destructive/80 mt-0.5">{creationState.error}</p>
+            </div>
+          </div>
+        )}
+
+        {/* Warnings Display */}
+        {creationState.warnings.length > 0 && (
+          <div className="space-y-1.5">
+            {creationState.warnings.map((warning, idx) => (
+              <div
+                key={idx}
+                className="flex items-start gap-2 p-2 rounded-md bg-yellow-500/10 border border-yellow-500/30"
+              >
+                <AlertTriangle className="h-3.5 w-3.5 text-yellow-500 shrink-0 mt-0.5" />
+                <p className="text-[10px] text-yellow-600 dark:text-yellow-400">{warning}</p>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // ---------- Review Mode ----------
+  const extrasLabels: string[] = [];
+  if (config.extras.gitignore) extrasLabels.push('.gitignore');
+  if (config.extras.editorconfig) extrasLabels.push('.editorconfig');
+  if (config.extras.envFile) extrasLabels.push('.env');
+  if (config.extras.hooks) extrasLabels.push('Git hooks');
+  if (config.extras.readme) extrasLabels.push('README.md');
+
+  return (
+    <div className="space-y-3">
+      <p className="text-[10px] text-muted-foreground">
+        Review your project configuration before creating.
+      </p>
+
+      <div className="rounded-md border border-border bg-muted/20 p-3 space-y-3">
+        {/* Basics */}
+        <ReviewSection title="Basics">
+          <ReviewRow label="Name" value={config.projectName || '(not set)'} />
+          <ReviewRow
+            label="Category"
+            value={<span className="capitalize">{config.category}</span>}
+          />
+          <ReviewRow label="Location" value={`${config.location}/${config.projectName}`} />
+          <ReviewRow
+            label="Type"
+            value={config.projectType === 'monorepo' ? 'Monorepo' : 'Single Project'}
+          />
+        </ReviewSection>
+
+        {/* Ecosystem */}
+        <ReviewSection title="Ecosystem">
+          <ReviewRow label="Ecosystem" value={config.ecosystem} />
+          {config.framework && <ReviewRow label="Framework" value={config.framework} />}
+          {config.projectType === 'monorepo' && config.monorepoTool && (
+            <ReviewRow label="Monorepo Tool" value={config.monorepoTool} />
+          )}
+          <ReviewRow label="Package Manager" value={config.packageManager} />
+        </ReviewSection>
+
+        {/* GitHub */}
+        <ReviewSection title="GitHub">
+          <ReviewRow label="Remote Repo" value={config.createGitHubRepo ? 'Yes' : 'No'} />
+          {config.createGitHubRepo && (
+            <>
+              <ReviewRow label="Visibility" value={config.repoVisibility} />
+              {config.repoDescription && (
+                <ReviewRow label="Description" value={config.repoDescription} />
+              )}
+            </>
+          )}
+        </ReviewSection>
+
+        {/* Extras */}
+        <ReviewSection title="Extras">
+          <ReviewRow
+            label="Files"
+            value={extrasLabels.length > 0 ? extrasLabels.join(', ') : 'None'}
+          />
+          <ReviewRow label="License" value={config.extras.license ?? 'None'} />
+        </ReviewSection>
+
+        {/* Database */}
+        <ReviewSection title="Database">
+          <ReviewRow
+            label="Engine"
+            value={config.database.engine === 'none' ? 'None' : config.database.engine}
+          />
+          {config.database.engine !== 'none' && (
+            <>
+              {config.database.orm && (
+                <ReviewRow label="ORM / Driver" value={config.database.orm} />
+              )}
+              <ReviewRow
+                label="Docker Compose"
+                value={config.database.includeDocker ? 'Yes' : 'No'}
+              />
+              <ReviewRow label=".env vars" value={config.database.includeEnvVars ? 'Yes' : 'No'} />
+              {config.database.additionalEngines.length > 0 && (
+                <ReviewRow
+                  label="Additional"
+                  value={config.database.additionalEngines.join(', ')}
+                />
+              )}
+            </>
+          )}
+        </ReviewSection>
+
+        {/* GitHub Config */}
+        {config.githubConfigSelections.length > 0 && (
+          <ReviewSection title="GitHub Config">
+            <ReviewRow
+              label="Templates"
+              value={`${config.githubConfigSelections.length} selected`}
+            />
+          </ReviewSection>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/hooks/useProjectCreation.ts
+++ b/src/renderer/hooks/useProjectCreation.ts
@@ -1,0 +1,307 @@
+import { useState } from 'react';
+import { ipc } from '../ipc/client';
+import { createLogger } from '../utils/logger';
+import type {
+  WizardConfig,
+  Contribution,
+  ToolDetectionResult,
+  ScaffoldConfig,
+  DatabaseScaffoldConfig,
+  Ecosystem,
+} from '../../main/ipc/channels';
+
+const logger = createLogger('ProjectCreation');
+
+type CreationStatus =
+  | 'idle'
+  | 'validating_tools'
+  | 'creating_directory'
+  | 'scaffolding'
+  | 'scaffolding_database'
+  | 'writing_extras'
+  | 'applying_github_config'
+  | 'initializing_git'
+  | 'creating_github_repo'
+  | 'pushing'
+  | 'saving_to_db'
+  | 'complete'
+  | 'error';
+
+interface CreationState {
+  status: CreationStatus;
+  progress: number;
+  currentStep: string;
+  error: string | null;
+  warnings: string[];
+  projectId: string | null;
+}
+
+const initialState: CreationState = {
+  status: 'idle',
+  progress: 0,
+  currentStep: '',
+  error: null,
+  warnings: [],
+  projectId: null,
+};
+
+export function useProjectCreation() {
+  const [state, setState] = useState<CreationState>(initialState);
+
+  const checkTools = async (
+    ecosystem: Ecosystem,
+    isMonorepo?: boolean,
+    monorepoTool?: string
+  ): Promise<ToolDetectionResult[]> => {
+    return ipc.invoke('project:check-cli-tools', ecosystem, isMonorepo, monorepoTool);
+  };
+
+  const startCreation = async (config: WizardConfig): Promise<Contribution> => {
+    const projectPath = `${config.location}/${config.projectName}`;
+    const warnings: string[] = [];
+
+    try {
+      // Step 1 (10%): Validate CLI tools
+      setState({
+        status: 'validating_tools',
+        progress: 10,
+        currentStep: 'Validating CLI tools...',
+        error: null,
+        warnings: [],
+        projectId: null,
+      });
+      logger.info('Validating CLI tools', { ecosystem: config.ecosystem });
+
+      const tools = await checkTools(
+        config.ecosystem,
+        config.projectType === 'monorepo',
+        config.monorepoTool
+      );
+      const missingRequired = tools.filter((t) => t.required && !t.installed);
+      if (missingRequired.length > 0) {
+        const names = missingRequired.map((t) => t.name).join(', ');
+        throw new Error(`Missing required tools: ${names}. Please install them and try again.`);
+      }
+
+      // Step 2 (20%): Create directory
+      setState({
+        status: 'creating_directory',
+        progress: 20,
+        currentStep: 'Creating project directory...',
+        error: null,
+        warnings: [...warnings],
+        projectId: null,
+      });
+      logger.info('Checking project directory', { projectPath });
+
+      const dirExists = await ipc.invoke('fs:directory-exists', projectPath);
+      if (dirExists) {
+        throw new Error(`Directory already exists: ${projectPath}`);
+      }
+
+      // Step 3 (40%): Scaffold project
+      setState({
+        status: 'scaffolding',
+        progress: 40,
+        currentStep: 'Scaffolding project...',
+        error: null,
+        warnings: [...warnings],
+        projectId: null,
+      });
+      logger.info('Scaffolding project', { projectName: config.projectName });
+
+      const scaffoldConfig: ScaffoldConfig = {
+        projectName: config.projectName,
+        projectPath,
+        ecosystem: config.ecosystem,
+        framework: config.framework,
+        packageManager: config.packageManager,
+        isMonorepo: config.projectType === 'monorepo',
+        monorepoTool: config.monorepoTool,
+        extras: {
+          gitignore: config.extras.gitignore,
+          editorconfig: config.extras.editorconfig,
+          envFile: config.extras.envFile,
+          readme: config.extras.readme,
+          license: config.extras.license || undefined,
+        },
+      };
+
+      const scaffoldResult = await ipc.invoke('project:scaffold', scaffoldConfig);
+      if (!scaffoldResult.success) {
+        throw new Error(`Scaffolding failed: ${scaffoldResult.message}`);
+      }
+      if (scaffoldResult.warnings.length > 0) {
+        warnings.push(...scaffoldResult.warnings);
+      }
+
+      // Step 4 (55%): Scaffold database
+      if (config.database.engine !== 'none') {
+        setState({
+          status: 'scaffolding_database',
+          progress: 55,
+          currentStep: 'Scaffolding database...',
+          error: null,
+          warnings: [...warnings],
+          projectId: null,
+        });
+        logger.info('Scaffolding database', { engine: config.database.engine });
+
+        const dbConfig: DatabaseScaffoldConfig = {
+          projectPath,
+          projectName: config.projectName,
+          ecosystem: config.ecosystem,
+          engine: config.database.engine,
+          orm: config.database.orm,
+          includeDocker: config.database.includeDocker,
+          includeEnvVars: config.database.includeEnvVars,
+          additionalEngines: config.database.additionalEngines,
+        };
+
+        const dbResult = await ipc.invoke('project:scaffold-database', dbConfig);
+        if (!dbResult.success) {
+          throw new Error(`Database scaffolding failed: ${dbResult.message}`);
+        }
+        if (dbResult.warnings.length > 0) {
+          warnings.push(...dbResult.warnings);
+        }
+      }
+
+      // Step 5 (65%): Apply GitHub config templates
+      if (config.githubConfigSelections.length > 0) {
+        setState({
+          status: 'applying_github_config',
+          progress: 65,
+          currentStep: 'Applying GitHub config templates...',
+          error: null,
+          warnings: [...warnings],
+          projectId: null,
+        });
+        logger.info('Applying GitHub config templates', {
+          count: config.githubConfigSelections.length,
+        });
+
+        for (const sel of config.githubConfigSelections) {
+          await ipc.invoke(
+            'github-config:create-from-template',
+            projectPath,
+            sel.featureId,
+            sel.templateId
+          );
+        }
+      }
+
+      // Step 6 (80%): Initialize git (init, checkout main, add, commit, checkout dev — no remote)
+      setState({
+        status: 'initializing_git',
+        progress: 80,
+        currentStep: 'Initializing git repository...',
+        error: null,
+        warnings: [...warnings],
+        projectId: null,
+      });
+      logger.info('Initializing git repository', { projectPath });
+
+      await ipc.invoke('project:initialize-git', projectPath);
+
+      // Step 7 (90%): Create GitHub repo if requested
+      let remoteUrl: string | undefined;
+      if (config.createGitHubRepo) {
+        setState({
+          status: 'creating_github_repo',
+          progress: 90,
+          currentStep: 'Creating GitHub repository...',
+          error: null,
+          warnings: [...warnings],
+          projectId: null,
+        });
+        logger.info('Creating GitHub repository', { name: config.projectName });
+
+        const repo = await ipc.invoke('project:create-github-repo', config.projectName, {
+          description: config.repoDescription,
+          isPrivate: config.repoVisibility === 'private',
+          autoInit: false,
+        });
+
+        remoteUrl = repo.url;
+
+        // Add remote and push
+        setState({
+          status: 'pushing',
+          progress: 93,
+          currentStep: 'Pushing to GitHub...',
+          error: null,
+          warnings: [...warnings],
+          projectId: null,
+        });
+        logger.info('Adding remote and pushing', { remoteUrl });
+
+        await ipc.invoke('git:add-remote', projectPath, 'origin', repo.url);
+        await ipc.invoke('git:push', projectPath, 'origin', 'main');
+        await ipc.invoke('git:push', projectPath, 'origin', 'dev');
+      }
+
+      // Step 8 (100%): Save to DB
+      setState({
+        status: 'saving_to_db',
+        progress: 97,
+        currentStep: 'Saving project to database...',
+        error: null,
+        warnings: [...warnings],
+        projectId: null,
+      });
+      logger.info('Saving project to database');
+
+      const contributionData: Omit<Contribution, 'id' | 'createdAt' | 'updatedAt'> = {
+        repositoryUrl: remoteUrl || projectPath,
+        localPath: projectPath,
+        branchName: 'dev',
+        status: 'in_progress',
+        type: 'project',
+        isFork: false,
+        remotesValid: !!remoteUrl,
+        ecosystem: config.ecosystem,
+        framework: config.framework,
+        packageManager: config.packageManager,
+        isMonorepo: config.projectType === 'monorepo',
+        monorepoTool: config.monorepoTool,
+        databaseEngine: config.database.engine !== 'none' ? config.database.engine : undefined,
+        databaseOrm: config.database.orm,
+      };
+
+      const contribution = await ipc.invoke('contribution:create', contributionData);
+
+      setState({
+        status: 'complete',
+        progress: 100,
+        currentStep: 'Project created successfully!',
+        error: null,
+        warnings: [...warnings],
+        projectId: contribution.id,
+      });
+      logger.info('Project creation complete', { projectId: contribution.id });
+
+      return contribution;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error('Project creation failed', { error: errorMessage });
+
+      setState({
+        status: 'error',
+        progress: 0,
+        currentStep: '',
+        error: errorMessage,
+        warnings: [...warnings],
+        projectId: null,
+      });
+
+      throw error;
+    }
+  };
+
+  const reset = () => {
+    setState(initialState);
+  };
+
+  return { state, startCreation, reset, checkTools };
+}

--- a/src/renderer/screens/ProfessionalProjectsScreen.tsx
+++ b/src/renderer/screens/ProfessionalProjectsScreen.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
+import { Plus } from 'lucide-react';
 import { ContributionList } from '../components/contributions/ContributionList';
+import { NewProjectWizard } from '../components/projects/NewProjectWizard';
+import { Button } from '../components/ui/Button';
 import { useProfessionalProjectsStore } from '../stores/useProfessionalProjectsStore';
 import { useSettingsStore } from '../stores/useSettingsStore';
 import { ipc } from '../ipc/client';
@@ -13,27 +16,28 @@ export function ProfessionalProjectsScreen({ onOpenIDE }: ProfessionalProjectsSc
   const { projects, deleteProject, setProjects } = useProfessionalProjectsStore();
   const { defaultProfessionalProjectsPath } = useSettingsStore();
   const [isScanning, setIsScanning] = React.useState(true);
+  const [wizardOpen, setWizardOpen] = React.useState(false);
+
+  const scanProjects = React.useCallback(async () => {
+    if (defaultProfessionalProjectsPath) {
+      setIsScanning(true);
+      try {
+        const scannedProjects = await ipc.invoke(
+          'project:scan-directory',
+          defaultProfessionalProjectsPath
+        );
+        setProjects(scannedProjects);
+      } catch {
+        // Scan failure handled by empty state
+      } finally {
+        setIsScanning(false);
+      }
+    }
+  }, [defaultProfessionalProjectsPath, setProjects]);
 
   React.useEffect(() => {
-    const scanProjects = async () => {
-      if (defaultProfessionalProjectsPath) {
-        setIsScanning(true);
-        try {
-          const scannedProjects = await ipc.invoke(
-            'project:scan-directory',
-            defaultProfessionalProjectsPath
-          );
-          setProjects(scannedProjects);
-        } catch {
-          // Scan failure handled by empty state
-        } finally {
-          setIsScanning(false);
-        }
-      }
-    };
-
     scanProjects();
-  }, [defaultProfessionalProjectsPath, setProjects]);
+  }, [scanProjects]);
 
   const handleOpenProject = (contribution: Contribution) => {
     if (onOpenIDE) {
@@ -41,11 +45,25 @@ export function ProfessionalProjectsScreen({ onOpenIDE }: ProfessionalProjectsSc
     }
   };
 
+  const handleWizardComplete = (contribution: Contribution) => {
+    setWizardOpen(false);
+    scanProjects();
+    if (onOpenIDE) {
+      onOpenIDE(contribution);
+    }
+  };
+
   return (
     <div className="p-8">
-      <div className="mb-6">
-        <h2 className="text-2xl font-bold">Professional Projects</h2>
-        <p className="text-muted-foreground mt-1">Manage your professional projects</p>
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">Professional Projects</h2>
+          <p className="text-muted-foreground mt-1">Manage your professional projects</p>
+        </div>
+        <Button size="sm" onClick={() => setWizardOpen(true)}>
+          <Plus className="h-4 w-4 mr-1" />
+          New Project
+        </Button>
       </div>
 
       <ContributionList
@@ -57,6 +75,14 @@ export function ProfessionalProjectsScreen({ onOpenIDE }: ProfessionalProjectsSc
           title: 'No projects found',
           subtitle: 'Add git repositories to your professional projects directory',
         }}
+      />
+
+      <NewProjectWizard
+        isOpen={wizardOpen}
+        onClose={() => setWizardOpen(false)}
+        onComplete={handleWizardComplete}
+        defaultCategory="professional"
+        defaultLocation={defaultProfessionalProjectsPath || ''}
       />
     </div>
   );

--- a/src/renderer/screens/ProjectsScreen.tsx
+++ b/src/renderer/screens/ProjectsScreen.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
+import { Plus } from 'lucide-react';
 import { ContributionList } from '../components/contributions/ContributionList';
+import { NewProjectWizard } from '../components/projects/NewProjectWizard';
+import { Button } from '../components/ui/Button';
 import { useProjectsStore } from '../stores/useProjectsStore';
 import { useSettingsStore } from '../stores/useSettingsStore';
 import { ipc } from '../ipc/client';
@@ -13,24 +16,25 @@ export function ProjectsScreen({ onOpenIDE }: ProjectsScreenProps) {
   const { projects, deleteProject, setProjects } = useProjectsStore();
   const { defaultProjectsPath } = useSettingsStore();
   const [isScanning, setIsScanning] = React.useState(true);
+  const [wizardOpen, setWizardOpen] = React.useState(false);
+
+  const scanProjects = React.useCallback(async () => {
+    if (defaultProjectsPath) {
+      setIsScanning(true);
+      try {
+        const scannedProjects = await ipc.invoke('project:scan-directory', defaultProjectsPath);
+        setProjects(scannedProjects);
+      } catch {
+        // Scan failure handled by empty state
+      } finally {
+        setIsScanning(false);
+      }
+    }
+  }, [defaultProjectsPath, setProjects]);
 
   React.useEffect(() => {
-    const scanProjects = async () => {
-      if (defaultProjectsPath) {
-        setIsScanning(true);
-        try {
-          const scannedProjects = await ipc.invoke('project:scan-directory', defaultProjectsPath);
-          setProjects(scannedProjects);
-        } catch {
-          // Scan failure handled by empty state
-        } finally {
-          setIsScanning(false);
-        }
-      }
-    };
-
     scanProjects();
-  }, [defaultProjectsPath, setProjects]);
+  }, [scanProjects]);
 
   const handleOpenProject = (contribution: Contribution) => {
     if (onOpenIDE) {
@@ -38,11 +42,25 @@ export function ProjectsScreen({ onOpenIDE }: ProjectsScreenProps) {
     }
   };
 
+  const handleWizardComplete = (contribution: Contribution) => {
+    setWizardOpen(false);
+    scanProjects();
+    if (onOpenIDE) {
+      onOpenIDE(contribution);
+    }
+  };
+
   return (
     <div className="p-8">
-      <div className="mb-6">
-        <h2 className="text-2xl font-bold">My Projects</h2>
-        <p className="text-muted-foreground mt-1">Manage your personal projects</p>
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">My Projects</h2>
+          <p className="text-muted-foreground mt-1">Manage your personal projects</p>
+        </div>
+        <Button size="sm" onClick={() => setWizardOpen(true)}>
+          <Plus className="h-4 w-4 mr-1" />
+          New Project
+        </Button>
       </div>
 
       <ContributionList
@@ -54,6 +72,14 @@ export function ProjectsScreen({ onOpenIDE }: ProjectsScreenProps) {
           title: 'No projects found',
           subtitle: 'Add git repositories to your projects directory',
         }}
+      />
+
+      <NewProjectWizard
+        isOpen={wizardOpen}
+        onClose={() => setWizardOpen(false)}
+        onComplete={handleWizardComplete}
+        defaultCategory="personal"
+        defaultLocation={defaultProjectsPath || ''}
       />
     </div>
   );

--- a/tests/main/database/schema.test.ts
+++ b/tests/main/database/schema.test.ts
@@ -8,8 +8,8 @@ describe('Database Schema', () => {
       expect(Number.isInteger(SCHEMA_VERSION)).toBe(true);
     });
 
-    it('is currently version 8', () => {
-      expect(SCHEMA_VERSION).toBe(8);
+    it('is currently version 9', () => {
+      expect(SCHEMA_VERSION).toBe(9);
     });
   });
 


### PR DESCRIPTION
## Summary

- **6-step New Project Wizard** modal accessible from both My Projects and Professional Projects screens, guiding users through Basics → Ecosystem → Options → GitHub Config → Database → Review & Create
- **Smart scaffolding** for 7 ecosystems (Node, Python, Rust, Go, Ruby, PHP, Java) with framework sub-choices (Next.js, Vite React/Vue/Svelte, Flask, Django, FastAPI, Actix, Rocket, Gin, Echo, Rails, Sinatra, Laravel, Symfony, Spring Boot, Micronaut) and monorepo support (Turborepo, Nx, pnpm workspaces, Cargo workspaces, Go workspaces, uv workspaces)
- **8 new IPC channels** (`project:scan-directory`, `project:check-cli-tools`, `project:scaffold`, `project:scaffold-database`, `project:get-orm-options`, `project:create-github-repo`, `project:initialize-git`, `project:validate-package-manager`, `project:install-tool`) with full type-safe handler registration
- **GitHub repository creation** via REST API with public/private visibility, optional auto-init, and remote setup
- **GitHub Config template integration** — wizard step lets users select from existing CI workflows, issue templates, PR templates, CODEOWNERS, auto-assign, Dependabot, and labeler configs to apply during project creation
- **Database scaffolding** — optional step to set up database engine (PostgreSQL, MySQL, SQLite, MongoDB, Redis) with ORM integration (Prisma, TypeORM, Drizzle, Sequelize, SQLAlchemy, Django ORM, Diesel, GORM, ActiveRecord, Eloquent) including schema files, config, and docker-compose generation
- **CLI tool detection service** with pre-flight validation for ecosystem runtimes and package managers, global install support, and DEP0190-safe execution
- **Smart package manager validation** — pre-flight check when leaving Ecosystem step detects if selected PM (bun, pnpm, yarn, uv, poetry) is installed; inline banner offers to switch to an installed alternative, install the tool globally, or continue anyway; auto-advances after successful install
- **Non-interactive scaffold flags** for Nx (`--interactive=false`, `--nxCloud=skip`, `--skipGit`), Turborepo (`--example basic`, `--skip-install`), and Next.js (`--yes`) to prevent CLI hangs
- **Schema migration v9** adding 7 project metadata columns (ecosystem, framework, package_manager, is_monorepo, monorepo_tool, database_engine, database_orm) to the contributions table
- **Creation pipeline** with 12-step progress: validate tools → create folder → scaffold → write extras (.gitignore, .editorconfig, README, LICENSE, .env) → apply GitHub configs → database setup → git init → initial commit → dev branch → GitHub repo → push → save to DB
- **Global dev scripts** tab in Settings for managing project-independent scripts, with migration of existing DevScriptsTool to support both project-scoped and global scripts

## New Files

| File | Purpose |
|---|---|
| `src/main/services/cli-detection.service.ts` | CLI tool detection, version checking, global install |
| `src/main/services/project-scaffold.service.ts` | Scaffold orchestration for all ecosystems + monorepos |
| `src/main/services/database-scaffold.service.ts` | Database + ORM scaffolding with docker-compose |
| `src/main/ipc/handlers/project.handlers.ts` | IPC handler registration for 8 project channels |
| `src/renderer/components/projects/NewProjectWizard.tsx` | 6-step wizard modal with creation pipeline |
| `src/renderer/components/projects/WizardStepBasics.tsx` | Step 1: name, category, location, type |
| `src/renderer/components/projects/WizardStepEcosystem.tsx` | Step 2: ecosystem, framework, monorepo, PM + validation banner |
| `src/renderer/components/projects/WizardStepOptions.tsx` | Step 3: GitHub visibility, extras checkboxes |
| `src/renderer/components/projects/WizardStepGitHubConfig.tsx` | Step 4: GitHub config template selection |
| `src/renderer/components/projects/WizardStepDatabase.tsx` | Step 5: database engine + ORM selection |
| `src/renderer/components/projects/WizardStepReview.tsx` | Step 6: summary + creation progress |
| `src/renderer/hooks/useProjectCreation.ts` | Creation pipeline hook with rollback |
| `src/renderer/components/settings/GlobalScriptsTab.tsx` | Settings tab for global dev scripts |

## Modified Files

| File | Change |
|---|---|
| `src/main/ipc/channels/types.ts` | Added wizard types, scaffold configs, tool detection interfaces, DB scaffold types |
| `src/main/ipc/channels/core.channels.ts` | Added 8 project channel definitions |
| `src/main/ipc/handlers/index.ts` | Registered `setupProjectHandlers` |
| `src/main/ipc/handlers.ts` | Added all project + install-tool channels to cleanup array |
| `src/main/database/schema.ts` | Schema v9 migration with 7 new columns |
| `src/main/database/database.service.ts` | Updated ContributionRow, createContribution, updateContribution, rowToContribution for new columns |
| `src/main/services/github/github-extras.service.ts` | Added `createRepository()` |
| `src/main/services/github/index.ts` | Exposed `createRepository` via facade |
| `src/renderer/screens/ProjectsScreen.tsx` | Added "New Project" button + wizard integration |
| `src/renderer/screens/ProfessionalProjectsScreen.tsx` | Added "New Project" button + wizard integration |
| `src/renderer/screens/SettingsScreen.tsx` | Added Global Scripts tab |
| `src/renderer/components/tools/DevScriptsTool.tsx` | Support for global scripts alongside project scripts |
| `src/renderer/stores/useDevScriptsStore.ts` | Added global scripts state management |
| `CHANGELOG.md` | Documented all changes under v1.1.0 |