### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `src/main/services/workflow.service.ts` to modify changelog generation rules, specifically removing blank line enforcement between bullet entries and adjusting rule numbering.
+- Modify `src/main/services/workflow.service.ts` to adjust the insertion logic for new changelog bullets, ensuring exactly one blank line after the heading.
+- Update `src/renderer/components/tools/ChangelogResult.tsx` to replace `pre` tag with a resizable `textarea` for displaying changelog entries, allowing user editing.
+
+### Added
+
+- Add a test case to `tests/main/services/workflow.service.test.ts` to verify the AI service prompt includes the rule about "NO blank lines between bullet entries".
+- Add a test case to `tests/main/services/workflow.service.test.ts` to ensure AI output is passed through without normalizing blank lines between bullets.
+- Add a test case to `tests/renderer/components/tools/ChangelogResult.test.tsx` to verify the changelog entry is displayed in an editable textarea.
+- Add a test case to `tests/renderer/components/tools/ChangelogResult.test.tsx` to ensure the user can edit the generated entry and apply the edited content.
+
+### Removed
+
+- Remove a test case from `tests/renderer/components/tools/ChangelogResult.test.tsx` that checked for changelog entry display in a non-editable format.
+
 ## [1.1.2] - 2026-03-15
 
 ### Added

--- a/src/main/services/workflow.service.ts
+++ b/src/main/services/workflow.service.ts
@@ -143,12 +143,13 @@ RULES:
    ### Fixed — for bug fixes
    ### Security — for vulnerability fixes
 4. Each entry starts with "- " (bullet)
-5. Use imperative mood ("Add X" not "Added X")
-6. Be specific — mention component names, file names, or feature names
-7. One bullet per distinct change. Cover ALL files listed below.
-8. No version numbers, no dates, no ## headings
-${resolvedIssue ? `9. Reference issue #${resolvedIssue} where relevant` : ''}
-${branchName ? `10. Branch context: ${branchName}` : ''}
+5. NO blank lines between bullet entries within the same category. Bullets must be consecutive lines.
+6. Use imperative mood ("Add X" not "Added X")
+7. Be specific — mention component names, file names, or feature names
+8. One bullet per distinct change. Cover ALL files listed below.
+9. No version numbers, no dates, no ## headings
+${resolvedIssue ? `10. Reference issue #${resolvedIssue} where relevant` : ''}
+${branchName ? `11. Branch context: ${branchName}` : ''}
 
 EXISTING CHANGELOG STYLE (match this tone and detail level):
 ${existingChangelog.slice(0, 800)}
@@ -280,9 +281,14 @@ ${diff.slice(0, 12000)}`;
         // Find the first bullet line, skipping any blank lines after the heading
         const firstBulletMatch = afterHeading.match(/^(\n*)(- )/);
         if (firstBulletMatch) {
-          // Insert new bullets before existing bullets, preserving the blank line after heading
-          const insertAt = endOfLine + 1 + firstBulletMatch[1].length;
-          content = content.slice(0, insertAt) + bulletBlock + '\n' + content.slice(insertAt);
+          // Insert new bullets before existing bullets, normalizing to exactly ONE blank line after heading
+          const insertAt = endOfLine + 1;
+          content =
+            content.slice(0, insertAt) +
+            '\n' +
+            bulletBlock +
+            '\n' +
+            content.slice(insertAt).replace(/^\n+/, '');
         } else {
           // No existing bullets under this heading — add after heading with blank line
           content = content.slice(0, endOfLine) + '\n\n' + bulletBlock + content.slice(endOfLine);

--- a/src/renderer/components/tools/ChangelogResult.tsx
+++ b/src/renderer/components/tools/ChangelogResult.tsx
@@ -105,9 +105,12 @@ export function ChangelogResult({
         <p className="text-[10px] text-muted-foreground">No changes detected.</p>
       ) : (
         <>
-          <pre className="text-[10px] text-foreground bg-background rounded p-2 overflow-auto styled-scroll max-h-48 whitespace-pre-wrap font-mono border border-border">
-            {entry}
-          </pre>
+          <textarea
+            className="text-[10px] text-foreground bg-background rounded p-2 overflow-auto styled-scroll max-h-48 whitespace-pre-wrap font-mono border border-border w-full resize-y"
+            value={entry}
+            onChange={(e) => setEntry(e.target.value)}
+            rows={entry.split('\n').length + 1}
+          />
           <div className="flex items-center gap-2 mt-2">
             {applied ? (
               <span className="flex items-center gap-1 text-[10px] text-green-600 dark:text-green-400">

--- a/tests/main/services/workflow.service.test.ts
+++ b/tests/main/services/workflow.service.test.ts
@@ -107,6 +107,33 @@ describe('WorkflowService', () => {
       expect(aiService.complete).toHaveBeenCalledWith(
         expect.objectContaining({ prompt: expect.stringContaining('Keep a Changelog') })
       );
+      expect(aiService.complete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: expect.stringContaining('NO blank lines between bullet entries'),
+        })
+      );
+    });
+
+    it('should pass through AI output without normalizing blank lines between bullets', async () => {
+      vi.mocked(gitService.getStatus).mockResolvedValue({
+        current: 'main',
+        tracking: null,
+        ahead: 0,
+        behind: 0,
+        files: [{ path: 'src/index.ts', index: 'M', working_dir: ' ' }],
+      });
+      vi.mocked(gitService.getDiff).mockResolvedValue('diff content');
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(aiService.complete).mockResolvedValue({
+        content: '### Fixed\n- Fix A\n\n- Fix B',
+        tokensUsed: 100,
+        model: 'gemini-2.5-flash',
+      });
+
+      const result = await workflowService.generateChangelog('/test/repo');
+
+      // generateChangelog should NOT normalize spacing — user can edit in textarea
+      expect(result.entry).toBe('### Fixed\n- Fix A\n\n- Fix B');
     });
 
     it('should strip conversational preamble from AI response', async () => {
@@ -425,6 +452,55 @@ describe('WorkflowService', () => {
       expect(existingFixIdx).toBeLessThan(v100Idx);
       // Released section untouched
       expect(written.indexOf('- Old')).toBeGreaterThan(v100Idx);
+    });
+
+    it('should normalize spacing to one blank line when injecting bullets (regression test for extra blank lines)', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      // Changelog with EXTRA blank lines after heading (malformed source)
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        '# Changelog\n\n## [Unreleased]\n\n### Added\n\n\n- Existing feature\n\n## [1.0.0]\n'
+      );
+
+      await workflowService.applyChangelog('/test/repo', '### Added\n- New feature');
+
+      const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+
+      // Extract the ### Added section from [Unreleased]
+      const addedHeadingIdx = written.indexOf('### Added');
+      const nextSectionIdx = written.indexOf('## [1.0.0]', addedHeadingIdx);
+      const addedSection = written.slice(addedHeadingIdx, nextSectionIdx);
+
+      // Verify exactly ONE blank line after heading, then bullets with no blank lines between them
+      const expectedSpacing = '### Added\n\n- New feature\n- Existing feature\n';
+      expect(addedSection).toContain(expectedSpacing);
+
+      // Verify no double newlines between bullets
+      expect(addedSection).not.toContain('- New feature\n\n- Existing feature');
+    });
+
+    it('should normalize AI-generated content with blank lines between bullets', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        '# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- Existing fix\n\n## [1.0.0]\n'
+      );
+
+      // AI generates with blank lines between bullets (common AI output format)
+      await workflowService.applyChangelog(
+        '/test/repo',
+        '### Fixed\n- New fix A\n\n- New fix B\n\n- New fix C'
+      );
+
+      const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+
+      const fixedIdx = written.indexOf('### Fixed');
+      const v100Idx = written.indexOf('## [1.0.0]', fixedIdx);
+      const fixedSection = written.slice(fixedIdx, v100Idx);
+
+      // Verify all bullets are present with NO blank lines between them
+      expect(fixedSection).toContain('- New fix A\n- New fix B\n- New fix C\n- Existing fix');
+
+      // Verify no double newlines between any bullets
+      expect(fixedSection).not.toMatch(/- [^\n]+\n\n- /);
     });
   });
 });

--- a/tests/renderer/components/tools/ChangelogResult.test.tsx
+++ b/tests/renderer/components/tools/ChangelogResult.test.tsx
@@ -35,7 +35,7 @@ describe('ChangelogResult', () => {
     expect(screen.getByText(/generating/i)).toBeDefined();
   });
 
-  it('should display generated changelog entry', async () => {
+  it('should display generated changelog entry in editable textarea', async () => {
     mockInvoke.mockResolvedValue({
       entry: '### Added\n- New button component',
       hasChanges: true,
@@ -44,7 +44,9 @@ describe('ChangelogResult', () => {
     render(<ChangelogResult {...defaultProps} />);
 
     await waitFor(() => {
-      expect(screen.getByText(/New button component/)).toBeDefined();
+      const textarea = screen.getByRole('textbox');
+      expect(textarea).toBeDefined();
+      expect((textarea as HTMLTextAreaElement).value).toContain('New button component');
     });
   });
 
@@ -128,6 +130,40 @@ describe('ChangelogResult', () => {
 
     await userEvent.click(screen.getByTitle('Close'));
     expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('should allow user to edit the generated entry and apply edited content', async () => {
+    mockInvoke.mockImplementation((channel: string) => {
+      if (channel === 'workflow:generate-changelog') {
+        return Promise.resolve({
+          entry: '### Added\n- Feature X',
+          hasChanges: true,
+        });
+      }
+      return Promise.resolve();
+    });
+
+    render(<ChangelogResult {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toBeDefined();
+    });
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+
+    // User edits the draft
+    await userEvent.clear(textarea);
+    await userEvent.type(textarea, '### Added\n- Feature X (updated)\n- Feature Y');
+
+    await userEvent.click(screen.getByText(/Apply to CHANGELOG/));
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith(
+        'workflow:apply-changelog',
+        '/test/project',
+        '### Added\n- Feature X (updated)\n- Feature Y'
+      );
+    });
   });
 
   it('should pass issue number and branch name', async () => {


### PR DESCRIPTION
## Summary
- Fix changelog button flow so AI only drafts entries, user can edit in an editable textarea, and the system handles insertion programmatically
- Remove normalization hack from `generateChangelog` that was masking spacing issues instead of fixing the root cause
- Add prompt rule instructing AI to not insert blank lines between bullet entries